### PR TITLE
build(deps): bump the production-dependencies group with 2 updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,10 +14,10 @@
         "csv-parser": "^3.2.0",
         "ejs": "^3.1.10",
         "express": "^4.21.2",
-        "express-rate-limit": "^7.5.0",
+        "express-rate-limit": "^7.5.1",
         "googleapis": "^150.0.1",
         "helmet": "^8.1.0",
-        "puppeteer-core": "^24.10.1"
+        "puppeteer-core": "^24.10.2"
       },
       "devDependencies": {
         "@eslint/js": "^9.29.0",
@@ -1934,9 +1934,9 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.0.tgz",
-      "integrity": "sha512-eB5zbQh5h+VenMPM3fh+nw1YExi5nMr6HUCR62ELSP11huvxm/Uir1H1QEyTkk5QX6A58pX6NmaTMceKZ0Eodg==",
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
+      "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
       "license": "MIT",
       "engines": {
         "node": ">= 16"
@@ -1945,7 +1945,7 @@
         "url": "https://github.com/sponsors/express-rate-limit"
       },
       "peerDependencies": {
-        "express": "^4.11 || 5 || ^5.0.0-beta.1"
+        "express": ">= 4.11"
       }
     },
     "node_modules/express/node_modules/debug": {
@@ -3428,9 +3428,9 @@
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "24.10.1",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.10.1.tgz",
-      "integrity": "sha512-AE6doA9znmEEps/pC5lc9p0zejCdNLR6UBp3EZ49/15Nbvh+uklXxGox7Qh8/lFGqGVwxInl0TXmsOmIuIMwiQ==",
+      "version": "24.10.2",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.10.2.tgz",
+      "integrity": "sha512-CnzhOgrZj8DvkDqI+Yx+9or33i3Y9uUYbKyYpP4C13jWwXx/keQ38RMTMmxuLCWQlxjZrOH0Foq7P2fGP7adDQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@puppeteer/browsers": "2.10.5",

--- a/package.json
+++ b/package.json
@@ -26,10 +26,10 @@
     "csv-parser": "^3.2.0",
     "ejs": "^3.1.10",
     "express": "^4.21.2",
-    "express-rate-limit": "^7.5.0",
+    "express-rate-limit": "^7.5.1",
     "googleapis": "^150.0.1",
     "helmet": "^8.1.0",
-    "puppeteer-core": "^24.10.1"
+    "puppeteer-core": "^24.10.2"
   },
   "type": "module",
   "devDependencies": {


### PR DESCRIPTION
Bumps the production-dependencies group with 2 updates: [express-rate-limit](https://github.com/express-rate-limit/express-rate-limit) and [puppeteer-core](https://github.com/puppeteer/puppeteer).


Updates `express-rate-limit` from 7.5.0 to 7.5.1
- [Release notes](https://github.com/express-rate-limit/express-rate-limit/releases)
- [Commits](https://github.com/express-rate-limit/express-rate-limit/compare/v7.5.0...v7.5.1)

Updates `puppeteer-core` from 24.10.1 to 24.10.2
- [Release notes](https://github.com/puppeteer/puppeteer/releases)
- [Changelog](https://github.com/puppeteer/puppeteer/blob/main/CHANGELOG.md)
- [Commits](https://github.com/puppeteer/puppeteer/compare/puppeteer-core-v24.10.1...puppeteer-core-v24.10.2)

---
updated-dependencies:
- dependency-name: express-rate-limit dependency-version: 7.5.1 dependency-type: direct:production update-type: version-update:semver-patch dependency-group: production-dependencies
- dependency-name: puppeteer-core dependency-version: 24.10.2 dependency-type: direct:production update-type: version-update:semver-patch dependency-group: production-dependencies ...