### PR TITLE
Reduce VM memory and scale in prod environment

### DIFF
--- a/fly.dev.toml
+++ b/fly.dev.toml
@@ -9,7 +9,7 @@ dockerfile = "Dockerfile.dev"
 ignorefile = ".dockerignore"
 
 [[vm]]
-memory = '1gb'
+memory = '512mb'
 cpu_kind = 'shared'
 cpus = 1
 
@@ -18,7 +18,6 @@ NODE_ENV = "development"
 LOG_LEVEL = "debug"
 DATA_AUTO_REFRESH = true
 DATA_AUTO_REFRESH_INTERVAL = 1800000
-
 
 [mounts]
 source = "dev_data_volume"

--- a/fly.prod.toml
+++ b/fly.prod.toml
@@ -9,7 +9,7 @@ dockerfile = "Dockerfile"
 ignorefile = ".dockerignore"
 
 [[vm]]
-memory = '1gb'
+memory = '512mb'
 cpu_kind = 'shared'
 cpus = 1
 
@@ -43,4 +43,4 @@ force_https = true
 auto_stop_machines = 'suspend'
 auto_start_machines = true
 min_machines_running = 0
-max_machines_running = 2
+max_machines_running = 1


### PR DESCRIPTION
Set memory to 512MB in both dev and prod configs, limit max machines running to 1 in prod

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reduced memory allocation for development and production environments from 1GB to 512MB.
  * Lowered the maximum number of concurrent machines in production from 2 to 1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->