### PR TITLE
Switch to Chrome headless shell for lower memory usage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,11 @@ COPY package.json bun.lock ./
 # Install dependencies
 RUN bun install --production
 
-# Install Chrome for Testing - https://developer.chrome.com/blog/chrome-for-testing
-RUN bunx @puppeteer/browsers install chrome@stable && \
-    echo "PUPPETEER_EXECUTABLE_PATH=$(find . -type f -name chrome | head -n 1)" >> .env
+# https://developer.chrome.com/blog/chrome-for-testing
+# Install Chrome for Testing with headless shell (lighter than full Chrome)
+# Use chrome-headless-shell for lower memory usage
+RUN bunx @puppeteer/browsers install chrome-headless-shell@stable && \
+    echo "PUPPETEER_EXECUTABLE_PATH=$(find . -type f -name chrome-headless-shell | head -n 1)" >> .env
 
 # Copy application code
 COPY . .
@@ -23,32 +25,26 @@ FROM oven/bun:1-slim
 
 WORKDIR /tourRanking
 
-# Required libs for Chrome which is used by Puppeteer
+# Minimal libs for Chrome headless shell (fewer dependencies = less memory)
 RUN apt-get update && apt-get install -y \
     ca-certificates \
-    curl \
     libglib2.0-0 \
     libnss3 \
-    libatk1.0-0 \
-    libdbus-1-3 \
-    libatk-bridge2.0-0 \
-    libcups2 \
-    libexpat1 \
-    libxkbcommon0 \
-    libxcomposite1 \
-    libxdamage1 \
-    libxfixes3 \
+    libxss1 \
+    libgconf-2-4 \
     libxrandr2 \
-    libgbm1 \
-    libpango-1.0-0 \
-    libcairo2 \
     libasound2 \
+    libpangocairo-1.0-0 \
+    libatk1.0-0 \
+    libcairo-gobject2 \
+    libgtk-3-0 \
+    libgdk-pixbuf2.0-0 \
     --no-install-recommends && \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/* && \
+    apt-get clean
 
 
 # Install Supercronic
-# Latest releases available at https://github.com/aptible/supercronic/releases
 ENV SUPERCRONIC_URL=https://github.com/aptible/supercronic/releases/download/v0.2.29/supercronic-linux-amd64 \
     SUPERCRONIC=supercronic-linux-amd64 \
     SUPERCRONIC_SHA1SUM=cd48d45c4b10f3f0bfdd3a57d054cd05ac96812b
@@ -59,8 +55,6 @@ RUN curl -fsSLO "$SUPERCRONIC_URL" \
     && mv "$SUPERCRONIC" "/usr/local/bin/${SUPERCRONIC}" \
     && ln -s "/usr/local/bin/${SUPERCRONIC}" /usr/local/bin/supercronic
 
-# You might need to change this depending on where your crontab is located
-
 # Copy from builder stage
 COPY --from=builder /tourRanking /tourRanking
 COPY crontab crontab
@@ -70,6 +64,7 @@ EXPOSE 8080
 
 # Set environment variables
 ENV NODE_ENV=production
+ENV NODE_OPTIONS="--max-old-space-size=256"
 ENV PORT=8080
 ENV DATA_DIR=/tourRanking/data/csv
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -7,32 +7,29 @@ WORKDIR /tourRanking
 COPY package.json bun.lock ./
 RUN bun install
 
-# Install Chrome for Testing first (this layer rarely changes)
-RUN bunx @puppeteer/browsers install chrome@stable && \
-    echo "PUPPETEER_EXECUTABLE_PATH=$(find . -type f -name chrome | head -n 1)" >> .env
+# https://developer.chrome.com/blog/chrome-for-testing
+# Install Chrome for Testing with headless shell (lighter than full Chrome)
+# Use chrome-headless-shell for lower memory usage
+RUN bunx @puppeteer/browsers install chrome-headless-shell@stable && \
+    echo "PUPPETEER_EXECUTABLE_PATH=$(find . -type f -name chrome-headless-shell | head -n 1)" >> .env
 
-# Required libs for Chrome
+# Minimal libs for Chrome headless shell (fewer dependencies = less memory)
 RUN apt-get update && apt-get install -y \
     ca-certificates \
-    curl \
     libglib2.0-0 \
     libnss3 \
-    libatk1.0-0 \
-    libdbus-1-3 \
-    libatk-bridge2.0-0 \
-    libcups2 \
-    libexpat1 \
-    libxkbcommon0 \
-    libxcomposite1 \
-    libxdamage1 \
-    libxfixes3 \
+    libxss1 \
+    libgconf-2-4 \
     libxrandr2 \
-    libgbm1 \
-    libpango-1.0-0 \
-    libcairo2 \
     libasound2 \
+    libpangocairo-1.0-0 \
+    libatk1.0-0 \
+    libcairo-gobject2 \
+    libgtk-3-0 \
+    libgdk-pixbuf2.0-0 \
     --no-install-recommends && \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/* && \
+    apt-get clean
 
 # Latest releases available at https://github.com/aptible/supercronic/releases
 ENV SUPERCRONIC_URL=https://github.com/aptible/supercronic/releases/download/v0.2.29/supercronic-linux-amd64 \
@@ -49,14 +46,14 @@ RUN curl -fsSLO "$SUPERCRONIC_URL" \
 # after deps are cached, bring in the rest
 COPY . .
 
-# Skip build step for faster iteration in dev
-# RUN bun run build
+RUN bun run build
 
 # Expose the port
 EXPOSE 8080
 
 # Set environment variables
 ENV NODE_ENV=development
+ENV NODE_OPTIONS="--max-old-space-size=256"
 ENV PORT=8080
 ENV DATA_DIR=/tourRanking/data/csv
 

--- a/src/scrappers/source/proCyclingStats/config.js
+++ b/src/scrappers/source/proCyclingStats/config.js
@@ -6,6 +6,8 @@
  * @property {Object} domains - .
  * @property {Object} domains.whitelist - List of domains to allow.
  * @property {Object} domains.blacklist - List of domains to block.
+ * @property {Object} resourceTypes - .
+ * @property {Object} resourceTypes.blacklist - List of resource types to block.
  * @property {number} wait - Wait time in milliseconds.
  */
 
@@ -13,8 +15,8 @@
 export const config = {
   browser: {
     executablePath: process.env.PUPPETEER_EXECUTABLE_PATH,
-    headless: true,
-    defaultViewport: null,
+    headless: "new",
+    defaultViewport: { width: 1024, height: 768 }, // Set explicit small viewport
     args: [
       "--no-sandbox",
       "--disable-setuid-sandbox",
@@ -24,6 +26,14 @@ export const config = {
       "--no-first-run",
       "--no-default-browser-check",
       "--no-zygote",
+      "--single-process", // Critical for memory reduction
+      "--memory-pressure-off",
+      "--disable-background-networking",
+      "--disable-background-timer-throttling",
+      "--disable-renderer-backgrounding",
+      "--disable-backgrounding-occluded-windows",
+      "--disable-features=TranslateUI,BlinkGenPropertyTrees",
+      "--max_old_space_size=256", // Limit Node.js heap
     ],
   },
   domains: {
@@ -32,7 +42,25 @@ export const config = {
       "ajax.googleapis.com",
       "code.jquery.com",
     ],
-    blacklist: [],
+    blacklist: [
+      "googletagmanager.com",
+      "google-analytics.com",
+      "facebook.com",
+      "twitter.com",
+      "doubleclick.net",
+      "googlesyndication.com",
+    ],
+  },
+  resourceTypes: {
+    blacklist: [
+      "image",
+      "media",
+      "font",
+      "stylesheet", // Only block if styling isn't needed for scraping
+      "websocket",
+      "manifest",
+      "other",
+    ],
   },
   wait: 420,
 };

--- a/src/scrappers/source/proCyclingStats/page_proCyclingStats.js
+++ b/src/scrappers/source/proCyclingStats/page_proCyclingStats.js
@@ -1,14 +1,20 @@
 import config from "./config";
 
 /**
- *
- * @param {Handler<HTTPRequest} request
+ * Enhanced request interceptor to block unnecessary resources and reduce bandwidth/memory usage
+ * @param {import('puppeteer-core').HTTPRequest} request - Puppeteer request object
  */
 export function interceptRequests(request) {
   const url = new URL(request.url());
   const domain = url.hostname;
+  const resourceType = request.resourceType();
 
-  if (config.domains.whitelist.includes(domain)) {
+  if (
+    config.domains.blacklist.includes(domain) ||
+    config.resourceTypes.blacklist.includes(resourceType)
+  ) {
+    request.abort();
+  } else if (config.domains.whitelist.includes(domain)) {
     request.continue();
   } else {
     request.abort();


### PR DESCRIPTION
The change reduces Docker image size and runtime memory by using Chrome's headless shell instead of full Chrome, optimizing Puppeteer settings, and blocking unnecessary resource types during scraping.