### PR TITLE
Fix array bounds check in ranking line animation

### DIFF
--- a/src/client/components/ranking/ranking.js
+++ b/src/client/components/ranking/ranking.js
@@ -48,9 +48,9 @@ export function createRankingComponent({
     line.attr("d", path(d));
     const newLength = element.getTotalLength();
     const greatestLength = oldLength > newLength ? oldLength : newLength;
-    const firstPoint = d[0].stage;
-    const lastPoint = d[d.length - 1].stage;
-    const steps = lastPoint - firstPoint;
+    const firstPoint = d.length > 0 ? d[0].stage : 0;
+    const lastPoint = d.length > 0 ? d[d.length - 1].stage : 0;
+    const steps = Math.max(0, lastPoint - firstPoint);
 
     line
       .attr("stroke-dasharray", oldLength + " " + greatestLength)


### PR DESCRIPTION
The stage calculation now handles empty arrays and ensures steps is non-negative.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of ranking animations by preventing errors when data is empty and ensuring animation durations are always valid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->