### PR TITLE
refactor: Table parsing for stage classifications

### DIFF
--- a/src/scrappers/source/proCyclingStats/raceStageResults.js
+++ b/src/scrappers/source/proCyclingStats/raceStageResults.js
@@ -269,12 +269,6 @@ function cleanUpStages(tables, stageUID, stage) {
             break;
 
           case "youth":
-            stageRankings[tab + "-day-classification"] = cleanUpStageTable(
-              ranking.standings,
-              { stageUID, stage },
-            );
-            break;
-
           case "teams":
             stageRankings[tab + "-day-classification"] = cleanUpStageTable(
               ranking.standings,
@@ -401,16 +395,14 @@ export async function scrapeRaceStageResults(page, race, year, stage) {
         ) {
           const columnLabel = columns[columnIndex];
           const cell = cells[columnIndex];
-          const nestedSpan = cell.querySelector("span");
-          const nestedDiv = cell.querySelector("div");
           let cellContent = cell.innerText.trim();
-
+          // const nestedSpan = cell.querySelector("span");
+          // const nestedDiv = cell.querySelector("div");
           // if (cell.classList.contains("time") && nestedSpan !== null) {
           //   cellContent = nestedDiv.innerText.trim();
           // } else {
           //   cellContent = cell.innerText.trim();
           // }
-
           rowDetails[columnLabel] = cellContent;
         }
 


### PR DESCRIPTION
This removes duplicate code for youth/team classifications and cleans up unused variables in stage result parsing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated how stage results are processed by removing special handling for "youth" rankings and simplifying the extraction of table data for race stages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->