### PR TITLE
Ignore js builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 # Build
 node_modules/
-/public/js/dist/
 /public/css/
+/public/js/*.js
+/public/js/*.js.map
 
 # OS files
 .DS_Store


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated git ignore patterns to exclude all JavaScript files and source maps in the public directory, broadening the scope of previously excluded build artefacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->