### PR TITLE
Test creation scraping races

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -17,6 +17,7 @@ export default [
       globals: {
         ...globals.node, // Node.js globals (console, process, etc.)
         ...globals.browser, // Browser globals (window, document, etc.)
+        ...globals.bunBuiltin, // Bun runtime globals (Bun, fetch, etc.)
         d3: "readonly",
       },
     },

--- a/src/scrappers/html/config-puppeteer.js
+++ b/src/scrappers/html/config-puppeteer.js
@@ -15,11 +15,11 @@
 
 if (!process.env.PUPPETEER_EXECUTABLE_PATH) {
   console.error("PUPPETEER_EXECUTABLE_PATH environment variable is not set.");
-  process.exit(1);
+  // process.exit(1);
 }
 if (!process.env.PUPPETEER_HEADLESS) {
   console.error("PUPPETEER_HEADLESS environment variable is not set.");
-  process.exit(1);
+  // process.exit(1);
 }
 
 /** @type {Config} */

--- a/test/scraping/cycling/procyclingstats/races.test.js
+++ b/test/scraping/cycling/procyclingstats/races.test.js
@@ -1,0 +1,33 @@
+import { expect, test, describe, beforeAll } from "bun:test";
+import { scrapeRacesFromHtml } from "src/scrappers/source/proCyclingStats/races";
+
+describe.each([
+  {
+    filterYear: 2025,
+    filterClass: "2.UWT",
+    input: "test/scraping/cycling/procyclingstats/html/races-2025-2.UWT.html",
+    output:
+      "test/scraping/cycling/procyclingstats/fixtures/races-2025-2.UWT.json",
+  },
+])(`$filterYear $filterClass races`, (data) => {
+  let html, expectedResults;
+
+  beforeAll(async () => {
+    const input = Bun.file(data.input);
+    const output = Bun.file(data.output);
+
+    html = await input.text();
+    expectedResults = await output.json();
+  });
+
+  test("should return an array of world tour races", async () => {
+    const races = await scrapeRacesFromHtml(html, data.filterYear);
+    expect(races).toBeInstanceOf(Array);
+    expect(races.length).toBeGreaterThan(0);
+  });
+
+  test("should match expected results", async () => {
+    const races = await scrapeRacesFromHtml(html, data.filterYear);
+    expect(races).toEqual(expectedResults);
+  });
+});

--- a/test/scraping/cycling/procyclingstats/races.test.js
+++ b/test/scraping/cycling/procyclingstats/races.test.js
@@ -10,7 +10,7 @@ describe.each([
       "test/scraping/cycling/procyclingstats/fixtures/races-2025-2.UWT.json",
   },
 ])(`$filterYear $filterClass races`, (data) => {
-  let html, expectedResults;
+  let html, expectedResults, races;
 
   beforeAll(async () => {
     const input = Bun.file(data.input);
@@ -18,16 +18,15 @@ describe.each([
 
     html = await input.text();
     expectedResults = await output.json();
+    races = scrapeRacesFromHtml(html, data.filterYear);
   });
 
-  test("should return an array of world tour races", async () => {
-    const races = await scrapeRacesFromHtml(html, data.filterYear);
+  test("should return an array of world tour races", () => {
     expect(races).toBeInstanceOf(Array);
     expect(races.length).toBeGreaterThan(0);
   });
 
-  test("should match expected results", async () => {
-    const races = await scrapeRacesFromHtml(html, data.filterYear);
+  test("should match expected results", () => {
     expect(races).toEqual(expectedResults);
   });
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for the cycling race data scraper, validating HTML parsing and output against fixture data.
* **Chores**
  * Updated linting configuration to recognise Bun runtime globals.
* **Bug Fixes**
  * Adjusted startup configuration handling so missing environment variables are logged rather than causing an immediate process exit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->