### PR TITLE
Add enpdoint for past seasons

### DIFF
--- a/src/server/controllers/raceController.js
+++ b/src/server/controllers/raceController.js
@@ -10,11 +10,16 @@ import { sortByDate } from "@server/utils/sorts.js";
 
 /**
  * Groups season races by their temporal status relative to today.
+ * @param {number} [season=null] - The season to fetch races for. Defaults to the current season.
  * @returns {TemporalSeasonRaces} An object with races grouped as current, upcoming, previous, and future.
  */
-export function seasonRaces() {
+export function seasonRaces(season = null) {
   const today = new Date();
-  const season = today.getFullYear();
+  const currentSeason = today.getFullYear();
+
+  if (!season || isNaN(season)) {
+    season = currentSeason;
+  }
 
   // Fetch races for the current season
   const races = dataService.seasonRaces(season);
@@ -45,7 +50,8 @@ export function seasonRaces() {
 
   // Sort each group by start date
   Object.keys(grouped).forEach((group) => {
-    const order = group === "previous" ? "desc" : "asc";
+    const order =
+      group === "previous" && season === currentSeason ? "desc" : "asc";
     grouped[group] = sortByDate(grouped[group], "startDate", order);
   });
 

--- a/src/server/routes/routesRoot.js
+++ b/src/server/routes/routesRoot.js
@@ -26,6 +26,52 @@ const router = express.Router();
  */
 
 /**
+ * Renders the home page with race data.
+ *
+ * @param {express.Response} res - The Express response object
+ * @param {Function} next - The Express next middleware function
+ * @param {HomePageContent} page - The page content object
+ */
+function renderSeasonPage(res, next, page) {
+  try {
+    const races = seasonRaces(page.season);
+    const hasRaceData =
+      races &&
+      (races.current?.length > 0 ||
+        races.upcoming?.length > 0 ||
+        races.previous?.length > 0 ||
+        races.future?.length > 0);
+
+    if (!hasRaceData) {
+      logError(
+        "Routes Root",
+        getErrorText("NO_DATA"),
+        new Error("seasonRaces() returned empty data"),
+      );
+      page.hasError = true;
+      page.errorMessage = getErrorHTML("NO_DATA");
+      res.status(503);
+    } else {
+      page.races = races;
+    }
+
+    res.render("pages/home", page);
+  } catch (error) {
+    logError("Routes Root", getErrorText("RENDER_ERROR"), error);
+    try {
+      res.status(500).render("pages/home", {
+        ...page,
+        hasError: true,
+        errorMessage: getErrorHTML("RENDER_ERROR"),
+      });
+    } catch (renderError) {
+      logError("Routes Root", getErrorText("CATASTROPHIC"), renderError);
+      next(error);
+    }
+  }
+}
+
+/**
  * Root route handler.
  * Serves the main HTML file for the root URL.
  *
@@ -45,52 +91,7 @@ router.get("/", (req, res, next) => {
     hasError: false,
   };
 
-  try {
-    const races = seasonRaces();
-
-    // Check if races data is available and has any content
-    const hasRaceData =
-      races &&
-      (races.current?.length > 0 ||
-        races.upcoming?.length > 0 ||
-        races.previous?.length > 0 ||
-        races.future?.length > 0);
-
-    // Check if races data is available and valid
-    if (!hasRaceData) {
-      logError(
-        "Routes Root",
-        getErrorText("NO_DATA"),
-        new Error("seasonRaces() returned empty data"),
-      );
-
-      page.hasError = true;
-      page.errorMessage = getErrorHTML("NO_DATA");
-      res.status(503);
-    } else {
-      page.races = races;
-    }
-
-    res.render("pages/home", page);
-  } catch (error) {
-    logError("Routes Root", getErrorText("RENDER_ERROR"), error);
-
-    // Instead of passing to error handler, render a graceful error state
-    try {
-      /** @type {HomePageContent} */
-      const errorPage = {
-        ...page,
-        hasError: true,
-        errorMessage: getErrorHTML("RENDER_ERROR"),
-      };
-
-      res.status(500).render("pages/home", errorPage);
-    } catch (renderError) {
-      // If even the error page fails to render, pass to Express error handler
-      logError("Routes Root", getErrorText("CATASTROPHIC"), renderError);
-      next(error);
-    }
-  }
+  renderSeasonPage(res, next, page);
 });
 
 /**
@@ -112,50 +113,7 @@ router.get("/season/:year?", (req, res, next) => {
     hasError: false,
   };
 
-  try {
-    const races = seasonRaces(year);
-
-    // Check if races data is available and has any content
-    const hasRaceData =
-      races &&
-      (races.current?.length > 0 ||
-        races.upcoming?.length > 0 ||
-        races.previous?.length > 0 ||
-        races.future?.length > 0);
-
-    if (!hasRaceData) {
-      logError(
-        "Routes Root",
-        getErrorText("NO_DATA"),
-        new Error("seasonRaces() returned empty data"),
-      );
-      page.hasError = true;
-      page.errorMessage = getErrorHTML("NO_DATA");
-      res.status(503);
-    } else {
-      page.races = races;
-    }
-
-    res.render("pages/home", page);
-  } catch (error) {
-    logError("Routes Root", getErrorText("RENDER_ERROR"), error);
-
-    // Instead of passing to error handler, render a graceful error state
-    try {
-      /** @type {HomePageContent} */
-      const errorPage = {
-        ...page,
-        hasError: true,
-        errorMessage: getErrorHTML("RENDER_ERROR"),
-      };
-
-      res.status(500).render("pages/home", errorPage);
-    } catch (renderError) {
-      // If even the error page fails to render, pass to Express error handler
-      logError("Routes Root", getErrorText("CATASTROPHIC"), renderError);
-      next(error);
-    }
-  }
+  renderSeasonPage(res, next, page);
 });
 
 export { router as routesRoot };

--- a/src/server/routes/routesRoot.js
+++ b/src/server/routes/routesRoot.js
@@ -2,6 +2,7 @@ import express from "express";
 import { seasonRaces } from "@server/controllers/raceController";
 import { logError } from "@utils/logging";
 import { getErrorHTML, getErrorText } from "@server/utils/errorMessages";
+import { validateYear } from "src/utils/date";
 
 const router = express.Router();
 
@@ -18,6 +19,7 @@ const router = express.Router();
  * @property {string} title - The title of the page
  * @property {string} description - The description of the page
  * @property {string} keywords - The keywords for the page
+ * @property {number} season - The number of seasons
  * @property {RacesData|null} races - Race data organized by status or null if unavailable
  * @property {boolean} hasError - Whether an error state should be displayed
  * @property {string} [errorMessage] - Optional user-friendly error message
@@ -34,11 +36,12 @@ const router = express.Router();
  */
 router.get("/", (req, res, next) => {
   /** @type {HomePageContent} */
-  const homePage = {
+  const page = {
     title: "Tour Rankings",
     description: "A web application for tracking and ranking tours.",
     keywords: "tour, ranking, web application",
     races: null,
+    season: null,
     hasError: false,
   };
 
@@ -61,14 +64,14 @@ router.get("/", (req, res, next) => {
         new Error("seasonRaces() returned empty data"),
       );
 
-      homePage.hasError = true;
-      homePage.errorMessage = getErrorHTML("NO_DATA");
+      page.hasError = true;
+      page.errorMessage = getErrorHTML("NO_DATA");
       res.status(503);
     } else {
-      homePage.races = races;
+      page.races = races;
     }
 
-    res.render("pages/home", homePage);
+    res.render("pages/home", page);
   } catch (error) {
     logError("Routes Root", getErrorText("RENDER_ERROR"), error);
 
@@ -76,7 +79,72 @@ router.get("/", (req, res, next) => {
     try {
       /** @type {HomePageContent} */
       const errorPage = {
-        ...homePage,
+        ...page,
+        hasError: true,
+        errorMessage: getErrorHTML("RENDER_ERROR"),
+      };
+
+      res.status(500).render("pages/home", errorPage);
+    } catch (renderError) {
+      // If even the error page fails to render, pass to Express error handler
+      logError("Routes Root", getErrorText("CATASTROPHIC"), renderError);
+      next(error);
+    }
+  }
+});
+
+/**
+ * Route handler for the season page.
+ * @param {Object} req - Express request object.
+ * @param {Object} res - Express response object.
+ * @param {Function} next - Express next middleware function.
+ */
+router.get("/season/:year?", (req, res, next) => {
+  const year = validateYear(req.params.year);
+
+  /** @type {HomePageContent} */
+  const page = {
+    title: "Tour Rankings",
+    description: `Season ${year || "Unknown"}`,
+    keywords: "tour, ranking, web application",
+    season: year,
+    races: null,
+    hasError: false,
+  };
+
+  try {
+    const races = seasonRaces(year);
+
+    // Check if races data is available and has any content
+    const hasRaceData =
+      races &&
+      (races.current?.length > 0 ||
+        races.upcoming?.length > 0 ||
+        races.previous?.length > 0 ||
+        races.future?.length > 0);
+
+    if (!hasRaceData) {
+      logError(
+        "Routes Root",
+        getErrorText("NO_DATA"),
+        new Error("seasonRaces() returned empty data"),
+      );
+      page.hasError = true;
+      page.errorMessage = getErrorHTML("NO_DATA");
+      res.status(503);
+    } else {
+      page.races = races;
+    }
+
+    res.render("pages/home", page);
+  } catch (error) {
+    logError("Routes Root", getErrorText("RENDER_ERROR"), error);
+
+    // Instead of passing to error handler, render a graceful error state
+    try {
+      /** @type {HomePageContent} */
+      const errorPage = {
+        ...page,
         hasError: true,
         errorMessage: getErrorHTML("RENDER_ERROR"),
       };

--- a/src/server/routes/routesRoot.js
+++ b/src/server/routes/routesRoot.js
@@ -19,7 +19,7 @@ const router = express.Router();
  * @property {string} title - The title of the page
  * @property {string} description - The description of the page
  * @property {string} keywords - The keywords for the page
- * @property {number} season - The number of seasons
+ * `@property` {number|null} season - The season year, or null for the current view
  * @property {RacesData|null} races - Race data organized by status or null if unavailable
  * @property {boolean} hasError - Whether an error state should be displayed
  * @property {string} [errorMessage] - Optional user-friendly error message

--- a/src/server/routes/routesRoot.js
+++ b/src/server/routes/routesRoot.js
@@ -46,7 +46,7 @@ function renderSeasonPage(res, next, page) {
       logError(
         "Routes Root",
         getErrorText("NO_DATA"),
-        new Error("seasonRaces(${year}) returned empty data"),
+        new Error(`seasonRaces(${page.season}) returned empty data`),
       );
       page.hasError = true;
       page.errorMessage = getErrorHTML("NO_DATA");

--- a/src/server/routes/routesRoot.js
+++ b/src/server/routes/routesRoot.js
@@ -105,7 +105,7 @@ router.get("/season/:year?", (req, res, next) => {
   /** @type {HomePageContent} */
   const page = {
     title: "Tour Rankings",
-    description: `Season ${year || "Unknown"}`,
+    description: `Season ${year}`,
     keywords: "tour, ranking, web application",
     season: year,
     races: null,

--- a/src/server/routes/routesRoot.js
+++ b/src/server/routes/routesRoot.js
@@ -46,7 +46,7 @@ function renderSeasonPage(res, next, page) {
       logError(
         "Routes Root",
         getErrorText("NO_DATA"),
-        new Error("seasonRaces() returned empty data"),
+        new Error("seasonRaces(${year}) returned empty data"),
       );
       page.hasError = true;
       page.errorMessage = getErrorHTML("NO_DATA");

--- a/src/server/routes/routesRoot.js
+++ b/src/server/routes/routesRoot.js
@@ -2,7 +2,7 @@ import express from "express";
 import { seasonRaces } from "@server/controllers/raceController";
 import { logError } from "@utils/logging";
 import { getErrorHTML, getErrorText } from "@server/utils/errorMessages";
-import { validateYear } from "src/utils/date";
+import { validateYear } from "@utils/date";
 
 const router = express.Router();
 

--- a/src/server/views/molecules/races--grouped.ejs
+++ b/src/server/views/molecules/races--grouped.ejs
@@ -2,7 +2,7 @@
   <h2><%= title %></h2>
   <div class="races--list">
     <% races.forEach(race => { %>
-      <a href="/race/<%= race.racePcsID %>"><%= race.raceName %></a>
-      <% }); %>
+    <a href="/race/<%= race.racePcsID %>/<%= race.year %>"><%= race.raceName %></a>
+    <%}) %>
   </div>
 </section>

--- a/src/server/views/organisms/raceLists.ejs
+++ b/src/server/views/organisms/raceLists.ejs
@@ -14,10 +14,17 @@
   <% } %>
 
   <% if (races.previous.length) { %>
-    <%- include('../molecules/races--grouped', {
-      title: 'Previous Races',
-      races: races.previous
-    })%>
+    <%  if (!races.future.length && !races.upcoming.length && !races.current.length) { %>
+        <%- include('../molecules/races--grouped', {
+          title: season,
+          races: races.previous
+        })%>
+    <% } else { %>
+        <%- include('../molecules/races--grouped', {
+            title: 'Previous Races',
+            races: races.previous
+        }) %>
+    <% }%>
   <% } %>
 
   <% if (races.future.length) { %>
@@ -26,4 +33,5 @@
       races: races.future
     })%>
   <% } %>
+
 </div>

--- a/src/server/views/organisms/raceLists.ejs
+++ b/src/server/views/organisms/raceLists.ejs
@@ -14,7 +14,7 @@
   <% } %>
 
   <% if (races.previous.length) { %>
-    <%  if (!races.future.length && !races.upcoming.length && !races.current.length) { %>
+    <%  if (season && !races.future.length && !races.upcoming.length && !races.current.length) { %>
         <%- include('../molecules/races--grouped', {
           title: season,
           races: races.previous


### PR DESCRIPTION
-- Added season parameters
-- Updated templates adds year to path.
-- Unreverses past races listings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * View races by season via an optional year in the URL (defaults to the current year).
  * Race links include the year for clearer navigation.
  * "Previous Races" will show the season name as its title when no other race categories exist.

* **Bug Fixes**
  * Robust handling when season is missing or invalid; consistent season fallback to current year.
  * More graceful, season-aware error display during rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->