### PR TITLE
fix(data): guard dispose() to prevent multiple calls

### DIFF
--- a/src/services/data/dataService.js
+++ b/src/services/data/dataService.js
@@ -58,6 +58,7 @@ class DataService {
     this._failureCount = 0;
     this._baseInterval = options.refreshInterval || 3600000;
     this._initializing = false;
+    this._disposed = false;
     this._refreshTimer = null;
     this.lastRefreshTime = null;
     this.isInitialized = false;
@@ -171,6 +172,7 @@ class DataService {
 
       this.isInitialized = true;
       this.lastRefreshTime = new Date();
+      this._disposed = false;
     } finally {
       this._initializing = false;
     }
@@ -182,6 +184,9 @@ class DataService {
    * @returns {void}
    */
   dispose() {
+    if (this._disposed) return;
+    this._disposed = true;
+
     logOut(this.constructor.name, "Disposing");
 
     if (this._refreshTimer) {


### PR DESCRIPTION
With bun --hot, each file change reloads dataServiceInstance.js, adding another process.once('exit') handler. After many reloads, all handlers fire on shutdown, calling dispose() dozens of times.

Add _disposed flag to guard against re-running cleanup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Made disposal operations idempotent to prevent issues from repeated shutdown calls, improving stability.
  * Ensured initialization correctly resets disposal state and properly manages refresh timers and initialization/refresh timestamps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->