### PR TITLE
fix(deps): remove Puppeteer/Chrome references from DEPLOYMENT.md

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -54,7 +54,7 @@ docker compose -f docker-compose.test.yml up
 **Features**:
 - Uses production Dockerfile
 - Tests multi-stage builds
-- Validates Chrome headless setup
+- Validates JSDOM + native fetch setup
 - Tests with production dependencies only
 - Simulates Fly.io environment locally
 
@@ -154,7 +154,7 @@ docker compose -f docker-compose.test.yml build --no-cache
 
 ### Memory Issues
 - Production Dockerfile sets `NODE_OPTIONS="--max-old-space-size=512"`
-- Matches 768MB VM allocation (512MB for Node, 256MB for system/Chrome)
+- Matches 768MB VM allocation (512MB for Node, ~256MB for JSDOM/parser)
 - If seeing OOM errors, check memory usage: `fly ssh console --config fly.prod.toml -C "free -m"`
 
 ### Data Persistence
@@ -168,7 +168,6 @@ docker compose -f docker-compose.test.yml build --no-cache
 - [ ] Test locally with `docker-compose.test.yml`
 - [ ] Verify build completes successfully
 - [ ] Check health endpoint responds
-- [ ] Ensure Chrome executable found
 
 ### Before Deploying to Production
 - [ ] All tests passing

--- a/src/scrappers/html/fetch.js
+++ b/src/scrappers/html/fetch.js
@@ -55,7 +55,6 @@ export async function fetchHtml(url, options = {}) {
 
 /**
  * Fetches HTML content with caching support
- * This is the recommended function to use when migrating away from Puppeteer
  *
  * @param {string} url - The URL to fetch
  * @param {FetchOptions & CacheOptions} [options] - Options for fetch and caching


### PR DESCRIPTION
Removes 3 outdated Chrome references:
- Line 57: "Chrome headless setup" → "JSODM + native fetch setup"
- Line 157: Update memory notes to JSDOM/parser
- Line 171: Remove Chrome executable checklist item

Closes #349

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated deployment guidelines and testing documentation to reflect current system configuration, including adjustments to memory allocation assessments and removal of outdated validation procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->