### PR TITLE
feat(data): add debounced file watching for near real-time data refresh

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,13 @@ DATA_DIR=./data/csv/
 DATA_AUTO_REFRESH=TRUE
 DATA_AUTO_REFRESH_INTERVAL=3600000
 
+# File Watching
+# Enable watching CSV files for changes (near real-time updates when scraper runs)
+DATA_WATCH_FILES=TRUE
+# Debounce duration in milliseconds (default: 60000 = 1 minute)
+# Prevents multiple refreshes when scraper writes after each stage
+DATA_WATCH_DEBOUNCE_MS=60000
+
 # Webscraping
 HTML_CACHE_ENABLED=true
 HTML_CACHE_DIR=./data/html

--- a/src/server/config.js
+++ b/src/server/config.js
@@ -77,6 +77,9 @@ const config = {
       process.env.DATA_AUTO_REFRESH?.toLowerCase() === "true" || false,
     refreshInterval:
       parseInt(process.env.DATA_AUTO_REFRESH_INTERVAL, 10) || 3600000,
+    watchFiles: process.env.DATA_WATCH_FILES?.toLowerCase() === "true" || false,
+    watchDebounceMs: parseInt(process.env.DATA_WATCH_DEBOUNCE_MS, 10) || 60000,
+    dataDir: process.env.DATA_DIR || "./data/csv/",
   },
 
   healthCheck: {

--- a/src/services/data/dataService.js
+++ b/src/services/data/dataService.js
@@ -55,7 +55,7 @@ class DataService {
       refreshInterval: 3600000, // 1 hour in ms
       watchFiles: false,
       watchDebounceMs: 60000, // 1 minute default
-      dataDir: process.env.DATA_DIR || "./data/csv/",
+      dataDir: "./data/csv/",
       ...options,
     };
 

--- a/src/services/data/dataService.js
+++ b/src/services/data/dataService.js
@@ -12,6 +12,8 @@ import {
   ClassificationYouth,
 } from "../../models";
 import { logError, logOut } from "@utils/logging";
+import { watch } from "fs";
+import { join, dirname } from "path";
 
 /**
  * Classes
@@ -51,6 +53,9 @@ class DataService {
     this.options = {
       autoRefresh: false,
       refreshInterval: 3600000, // 1 hour in ms
+      watchFiles: false,
+      watchDebounceMs: 60000, // 1 minute default
+      dataDir: process.env.DATA_DIR || "./data/csv/",
       ...options,
     };
 
@@ -60,6 +65,8 @@ class DataService {
     this._initializing = false;
     this._disposed = false;
     this._refreshTimer = null;
+    this._fileWatcher = null;
+    this._debounceTimer = null;
     this.lastRefreshTime = null;
     this.isInitialized = false;
 
@@ -122,26 +129,16 @@ class DataService {
         !this._refreshTimer &&
         typeof window === "undefined"
       ) {
-        const scheduleNextRefresh = (delay = this._baseInterval) => {
-          this._refreshTimer = setTimeout(async () => {
-            try {
-              await this.refreshData();
-              scheduleNextRefresh(this._baseInterval);
-            } catch (err) {
-              const backoffDelay = Math.min(
-                this._baseInterval * Math.pow(2, this._failureCount - 1),
-                this._baseInterval * 8,
-              );
-              logError(this.constructor.name, err?.message || String(err), err);
-              scheduleNextRefresh(backoffDelay);
-            }
-          }, delay);
-          this._refreshTimer.unref?.();
-        };
-        scheduleNextRefresh();
+        this._scheduleNextRefresh(this._baseInterval);
+      }
 
-        // Do not keep process alive solely for the timer (Node.js)
-        this._refreshTimer.unref?.();
+      // Set up file watching if enabled (only in Node.js, not browser)
+      if (
+        this.options.watchFiles &&
+        !this._fileWatcher &&
+        typeof window === "undefined"
+      ) {
+        this._setupFileWatcher();
       }
 
       // Determine success and log all failures
@@ -190,12 +187,128 @@ class DataService {
     logOut(this.constructor.name, "Disposing");
 
     if (this._refreshTimer) {
-      clearInterval(this._refreshTimer);
+      clearTimeout(this._refreshTimer);
       this._refreshTimer = null;
+    }
+
+    if (this._debounceTimer) {
+      clearTimeout(this._debounceTimer);
+      this._debounceTimer = null;
+    }
+
+    if (this._fileWatcher) {
+      this._fileWatcher.close();
+      this._fileWatcher = null;
     }
 
     this.isInitialized = false;
     this.lastRefreshTime = null;
+  }
+
+  /**
+   * Sets up file watching for CSV data directory.
+   * Triggers debounced refresh when files change.
+   *
+   * @private
+   * @returns {void}
+   */
+  _setupFileWatcher() {
+    const dataDir = this.options.dataDir;
+
+    try {
+      this._fileWatcher = watch(dataDir, { recursive: true }, (eventType, filename) => {
+        // Only watch CSV files
+        if (!filename || !filename.endsWith('.csv')) {
+          return;
+        }
+
+        // Clear existing debounce timer
+        if (this._debounceTimer) {
+          clearTimeout(this._debounceTimer);
+          this._debounceTimer = null;
+        }
+
+        const debounceSeconds = this.options.watchDebounceMs / 1000;
+        logOut(
+          this.constructor.name,
+          `File ${filename} changed, scheduling refresh in ${debounceSeconds}s`
+        );
+
+        // Start new debounce timer
+        this._debounceTimer = setTimeout(async () => {
+          try {
+            logOut(this.constructor.name, "Refresh triggered by file watcher");
+            await this._refreshAndResetPolling();
+          } catch (err) {
+            logError(
+              this.constructor.name,
+              "File-triggered refresh failed",
+              err?.message || String(err)
+            );
+          }
+        }, this.options.watchDebounceMs);
+
+        // Don't keep process alive for debounce timer
+        this._debounceTimer.unref?.();
+      });
+
+      logOut(this.constructor.name, `Watching ${dataDir} for changes`);
+    } catch (err) {
+      logError(
+        this.constructor.name,
+        `Failed to set up file watcher for ${dataDir}`,
+        err?.message || String(err)
+      );
+    }
+  }
+
+  /**
+   * Refreshes data and resets the polling timer to prevent
+   * double refresh (watcher + polling close together).
+   *
+   * @private
+   * @returns {Promise<void>}
+   */
+  async _refreshAndResetPolling() {
+    // Clear polling timer to prevent immediate double refresh
+    if (this._refreshTimer) {
+      clearTimeout(this._refreshTimer);
+      this._refreshTimer = null;
+      logOut(this.constructor.name, "Polling timer reset after file-triggered refresh");
+    }
+
+    await this.refreshData();
+
+    // Reschedule polling timer if auto-refresh is enabled
+    if (this.options.autoRefresh && typeof window === "undefined") {
+      this._scheduleNextRefresh(this._baseInterval);
+    }
+  }
+
+  /**
+   * Schedules the next polling refresh.
+   *
+   * @private
+   * @param {number} delay - Delay in milliseconds
+   * @returns {void}
+   */
+  _scheduleNextRefresh(delay) {
+    this._refreshTimer = setTimeout(async () => {
+      try {
+        await this.refreshData();
+        this._scheduleNextRefresh(this._baseInterval);
+      } catch (err) {
+        this._failureCount++;
+        const backoffDelay = Math.min(
+          this._baseInterval * Math.pow(2, this._failureCount - 1),
+          this._baseInterval * 8,
+        );
+        logError(this.constructor.name, err?.message || String(err), err);
+        this._scheduleNextRefresh(backoffDelay);
+      }
+    }, delay);
+
+    this._refreshTimer.unref?.();
   }
 
   /**


### PR DESCRIPTION
Implements file system watching on CSV data directory with debounced refresh (default 1 minute). This eliminates the lag between scraper updates and server data refresh.

Key features:
- Watch DATA_DIR for CSV file changes using fs.watch
- 1-minute debounce prevents multiple refreshes during scraper runs
- Resets polling timer after file-triggered refresh to avoid double refresh
- Configurable via DATA_WATCH_FILES and DATA_WATCH_DEBOUNCE_MS env vars
- Falls back to existing polling behavior when file watching disabled

Closes: data refresh lag between scraper and server