### PR TITLE
docs(agents): enhance Shape Up issue creation guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -187,6 +187,24 @@ Returns empty array instead of 500 error when no data exists.
 - **Cycle → Main**: Always merge commit, tag with `v{cycle}.0`
 - **Hotfixes**: Create bugfix/ branch, merge to main, then merge to current cycle
 
+### Git Best Practices
+
+**Never change the remote URL protocol.** The repository uses SSH (`git@github.com:...`) by default.
+
+If SSH authentication fails:
+1. Do NOT change the remote to HTTPS
+2. Fix the SSH key issue instead (e.g., load from password manager, run `ssh-add`)
+3. Check SSH connectivity: `ssh -T git@github.com`
+
+**Useful commands:**
+```bash
+# Check current remote
+git remote -v
+
+# Restore SSH if accidentally changed
+git remote set-url origin git@github.com:mattay/tourrankings.git
+```
+
 ## Project Structure
 
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -222,18 +222,20 @@ GitHub Actions runs on PRs and pushes:
 > "A problem well stated is a problem half solved."  
 > — Charles F. Kettering
 
-Shape Up distinguishes between **having an idea** and **shaping work**. Most failed bets fail not because of execution, but because the problem was never clearly understood. Resist the urge to jump straight to solutions.
+In this project, "creating an issue" means creating a GitHub issue following the Shape Up methodology from Basecamp. Shape Up distinguishes between **having an idea** and **shaping work**. Most failed bets fail not because of execution, but because the problem was never clearly understood. Resist the urge to jump straight to solutions.
+
+**Reference:** [Basecamp's Shape Up](https://basecamp.com/shapeup) - A methodology for shipping work in 6-week cycles.
 
 ### Which Template to Use?
 
 | If you... | Use | Labels |
 |-----------|-----|--------|
-| Have a vague concept, feeling something is wrong, or see an opportunity but can't articulate it yet | 💡 Raw Idea | `raw-idea`, `needs-shaping` |
-| Can clearly state the problem AND have a shaped solution approach | 📋 Pitch | `pitch`, `needs-betting` |
+| Have a vague concept, feeling something is wrong, or see an opportunity but can't articulate it yet | Raw Idea | `raw-idea`, `needs-shaping` |
+| Can clearly state the problem AND have a shaped solution approach | Pitch | `pitch`, `needs-betting` |
 
 **Critical:** If you find yourself writing solution details in a Raw Idea, stop. You're shaping prematurely. Move those thoughts to a comment or separate doc, and focus the issue on defining the problem.
 
-### 1. 💡 Raw Idea Template
+### 1. Raw Idea Template
 
 **Use when:** You have a concept but haven't shaped it yet. The problem is fuzzy. You might not even be sure it's worth solving.
 
@@ -267,7 +269,7 @@ reflect scraper updates much faster.
 - Both run in same container with shared volume
 ```
 
-### 2. 📋 Pitch Template
+### 2. Pitch Template
 
 **Use when:** Work is shaped and ready for betting. You deeply understand the problem AND have a solution approach that fits an appetite.
 
@@ -307,10 +309,10 @@ Small Batch (1-2 weeks) / Big Batch (4-6 weeks)
 
 ```bash
 # Raw Idea
-gh issue create --label raw-idea --label needs-shaping --title "💡 Idea: [title]" --body "[description]"
+gh issue create --label raw-idea --label needs-shaping --title "Idea: [title]" --body "[description]"
 
 # Pitch (using template)
-gh issue create --label pitch --label needs-betting --title "📋 Pitch: [title]" --body-file - <<'EOF'
+gh issue create --label pitch --label needs-betting --title "Pitch: [title]" --body-file - <<'EOF'
 ## Appetite
 Small Batch (1-2 weeks)
 
@@ -330,8 +332,8 @@ EOF
 
 ### The Path from Idea to Built
 
-```
-💡 Raw Idea → [Shaping] → 📋 Pitch → [Betting] → 🔄 bet/ Branch → [Build] → ✅ Merged
+```text
+Raw Idea → [Shaping] → Pitch → [Betting] → bet/ Branch → [Build] → Merged
      ↑                           ↓
 [needs-shaping]           [needs-betting]
      ↓                           ↓

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -219,33 +219,98 @@ GitHub Actions runs on PRs and pushes:
 
 ## Creating Shape Up Issues
 
-### Issue Types
+> "A problem well stated is a problem half solved."  
+> — Charles F. Kettering
 
-1. **Raw Idea** - Use when you have a concept but haven't shaped it yet
-   - Template: "💡 Raw Idea"
-   - Labels: `raw-idea`, `needs-shaping`
-   - Auto-moves to: Shaping Board → Raw Ideas
+Shape Up distinguishes between **having an idea** and **shaping work**. Most failed bets fail not because of execution, but because the problem was never clearly understood. Resist the urge to jump straight to solutions.
 
-2. **Pitch** - Use when work is shaped and ready for betting
-   - Template: "📋 Pitch"
-   - Labels: `pitch`, `needs-betting`
-   - Auto-moves to: Shaping Board → Ready for Betting
-   - Required fields:
-     - **Appetite:** Small Batch (1-2 weeks) or Big Batch (4-6 weeks)
-     - **Problem Statement:** What user problem does this solve?
-     - **Solution (Shaped):** High-level approach (not detailed specs)
-   - Optional fields:
-     - **Rabbit Holes:** What could go wrong or take too long?
-     - **No-Gos:** What are we explicitly NOT doing?
+### Which Template to Use?
+
+| If you... | Use | Labels |
+|-----------|-----|--------|
+| Have a vague concept, feeling something is wrong, or see an opportunity but can't articulate it yet | 💡 Raw Idea | `raw-idea`, `needs-shaping` |
+| Can clearly state the problem AND have a shaped solution approach | 📋 Pitch | `pitch`, `needs-betting` |
+
+**Critical:** If you find yourself writing solution details in a Raw Idea, stop. You're shaping prematurely. Move those thoughts to a comment or separate doc, and focus the issue on defining the problem.
+
+### 1. 💡 Raw Idea Template
+
+**Use when:** You have a concept but haven't shaped it yet. The problem is fuzzy. You might not even be sure it's worth solving.
+
+**Goal:** Capture the concept so it can be shaped later. Don't try to solve it here.
+
+**Template:**
+```markdown
+## Current Situation
+[What is happening now? Be specific with examples.]
+
+## Pain Point / Opportunity
+[What feels wrong or what could be better? Avoid solutions.]
+
+## Context
+[Any background that might help when shaping: user feedback, data, constraints]
+```
+
+**Example:**
+```markdown
+## Current Situation
+When the scraper finishes updating race results, users don't see the new data 
+for up to 75 minutes (scraper runs every 45 min + server refreshes every 30 min).
+
+## Pain Point / Opportunity
+During live races, users are looking at stale stage results. The server should 
+reflect scraper updates much faster.
+
+## Context
+- Scraper writes CSV files after every stage
+- Server uses timer-based polling (30 min interval)
+- Both run in same container with shared volume
+```
+
+### 2. 📋 Pitch Template
+
+**Use when:** Work is shaped and ready for betting. You deeply understand the problem AND have a solution approach that fits an appetite.
+
+**Required Fields:**
+
+| Field | Purpose | Good Example | Bad Example |
+|-------|---------|--------------|-------------|
+| **Appetite** | Time box that forces scope decisions | "Small Batch (1-2 weeks) — can implement file watching with debounce" | "Medium" |
+| **Problem Statement** | The specific user pain. Should be undeniable. | "Users wait 75 min for fresh data during live races" | "We need better caching" |
+| **Solution (Shaped)** | High-level approach, not detailed specs | "Watch CSV directory, debounce 1 min, reset polling timer" | "Implement fs.watch with recursive option set to true..." |
+
+**Optional Fields:**
+- **Rabbit Holes:** What could go wrong or take unexpectedly long?
+- **No-Gos:** What are we explicitly NOT doing? (Scope boundaries)
+
+**Template:**
+```markdown
+## Appetite
+Small Batch (1-2 weeks) / Big Batch (4-6 weeks)
+
+## Problem Statement
+[One or two sentences that capture the user pain. Include evidence if available.]
+
+## Solution (Shaped)
+[High-level approach. Not implementation details.]
+
+## Rabbit Holes
+- [What could be harder than expected?]
+- [What don't we understand yet?]
+
+## No-Gos
+- [What are we NOT doing?]
+- [What's out of scope?]
+```
 
 ### Creating Issues via GitHub CLI
 
 ```bash
 # Raw Idea
-gh issue create --label raw-idea --label needs-shaping --title "Idea: [title]" --body "[description]"
+gh issue create --label raw-idea --label needs-shaping --title "💡 Idea: [title]" --body "[description]"
 
 # Pitch (using template)
-gh issue create --label pitch --label needs-betting --title "[title]" --body-file - <<'EOF'
+gh issue create --label pitch --label needs-betting --title "📋 Pitch: [title]" --body-file - <<'EOF'
 ## Appetite
 Small Batch (1-2 weeks)
 
@@ -263,12 +328,22 @@ Small Batch (1-2 weeks)
 EOF
 ```
 
-### Workflow
+### The Path from Idea to Built
 
-1. **Have an idea?** → Create Raw Idea issue → Gets shaped → Convert to Pitch
-2. **Work is shaped?** → Create Pitch directly → Betting → Development
+```
+💡 Raw Idea → [Shaping] → 📋 Pitch → [Betting] → 🔄 bet/ Branch → [Build] → ✅ Merged
+     ↑                           ↓
+[needs-shaping]           [needs-betting]
+     ↓                           ↓
+   Shaping Board            Ready for Betting
+```
 
-The Shaping Board project automatically organizes issues by label.
+**Key transitions:**
+1. **Raw Idea → Pitch:** You understand the problem deeply and have shaped a solution
+2. **Pitch → Betting:** Work is selected for the current cycle
+3. **Bet → Build:** Development begins on a `bet/` branch
+
+**Circuit Breaker:** If work exceeds appetite, convert bet to `circuit-breaker/` branch. Document what was learned.
 
 ## Development Tips
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This file provides context and guidelines for agentic coding agents operating in
 
 ## Project Overview
 
-Tour Rankings is a cycling race data website with two distinct parts:
+Tour Rankings is a website to visulise classification rankings of multi-stage cycling races with two distinct parts:
 
 1. **Scraper** - Collects race data from ProCyclingStats and writes to CSV
 2. **Web App** - Express server + client-side JavaScript for visualization
@@ -89,7 +89,7 @@ const { logOut } = require("@utils/logging");  // BAD: throws in ESM
 
 ### JSDoc
 
-Add JSDoc comments for public APIs, especially in the server and services:
+Add JSDoc comments for all functions and type definitons
 
 ```javascript
 /**
@@ -193,38 +193,38 @@ Returns empty array instead of 500 error when no data exists.
 
 If SSH authentication fails:
 1. Do NOT change the remote to HTTPS
-2. Fix the SSH key issue instead (e.g., load from password manager, run `ssh-add`)
-3. Check SSH connectivity: `ssh -T git@github.com`
+2. Credentials may not have been approved. SSH key may be in a password manager.
 
-**Useful commands:**
-```bash
-# Check current remote
-git remote -v
-
-# Restore SSH if accidentally changed
-git remote set-url origin git@github.com:mattay/tourrankings.git
-```
 
 ## Project Structure
 
 ```
+data/           # Race data (csv, html, raw)
+public/         # Static assets
+scripts/        # Build & workflow scripts
 src/
-├── scrappers/          # Data collection
-│   ├── html/           # HTML fetching, parsing, caching
-│   └── source/         # Site-specific scrapers
-├── server/             # Express server
-│   ├── routes/        # API and view routes
-│   ├── middleware/    # Error handling, etc.
-│   └── config/
-├── services/           # Data loading from CSV
-├── client/            # Browser-side code
-│   ├── api/          # Client API calls
-│   ├── domain/       # Cycling-specific parsing
-│   └── styles/       # CSS
-test/
-├── scraping/          # Tests for scrapers
-└── utils/            # Utility function tests
+├── client/     # Browser JS (state, feedback)
+├── core/       # Cycling domain logic
+├── models/     # CSV-backed data models
+├── scrappers/  # ProCyclingStats scraper
+├── server/     # Express server (controllers, routes, views, middleware)
+├── services/   # Data services (CSV, Google Sheets)
+└── utils/      # Shared utilities
+test/           # Tests (Errors/, scraping/, server/, utils/)
 ```
+
+**Key entry points:**
+- `src/server/index.js` - Server boot
+- `src/client/index.js` - Client JS boot
+- `src/scrappers/scrape_proCyclingStats.js` - Scraper entry
+
+**Key services:**
+- `src/services/dataServiceInstance.js` - Data service singleton
+- `src/services/data/dataService.js` - CSV data loading
+
+**Key patterns:**
+- CSV-backed models in `src/models/`
+- EJS server-side templates in `src/server/views/`
 
 ## CI/CD
 
@@ -296,7 +296,7 @@ reflect scraper updates much faster.
 | Field | Purpose | Good Example | Bad Example |
 |-------|---------|--------------|-------------|
 | **Appetite** | Time box that forces scope decisions | "Small Batch (1-2 weeks) — can implement file watching with debounce" | "Medium" |
-| **Problem Statement** | The specific user pain. Should be undeniable. | "Users wait 75 min for fresh data during live races" | "We need better caching" |
+| **Problem Statement** | The specific user pain. it should be undeniable. | "Users wait 75 min for fresh data during live races" | "We need better caching" |
 | **Solution (Shaped)** | High-level approach, not detailed specs | "Watch CSV directory, debounce 1 min, reset polling timer" | "Implement fs.watch with recursive option set to true..." |
 
 **Optional Fields:**


### PR DESCRIPTION
Improves the "Creating Shape Up Issues" section with:

- Kettering quote on problem definition
- Decision table for Raw Idea vs Pitch selection
- Warning against premature solution-writing in Raw Ideas
- Enhanced Raw Idea template with Current Situation/Pain Point structure
- Real-world example from recent file watcher feature
- Detailed Pitch template with required/optional field explanations
- Quality examples vs bad examples comparison table
- Visual workflow diagram showing idea → pitch → bet → merge path
- Circuit breaker guidance for scope management

This better guides agents (and humans) to properly shape work before building, reducing failed bets due to poorly understood problems.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reworked Shape Up issue-creation guidance with a prescriptive decision flow and “Which Template to Use?” table.
  * Added complete Raw Idea and Pitch templates (with purpose table and example content) and a “Critical” constraint to protect Raw Ideas.
  * Updated CLI Pitch title prefix to "Pitch: ...".
  * Enhanced process visuals with diagrams, explicit key transitions and a circuit-breaker instruction for over-appetite work.
  * Added SSH-focused Git best-practice guidance for reliable repository access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->