### PR TITLE
fix(models): validate DATA_DIR environment variable before use

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "deploy:prod:logs": "fly logs --config fly.prod.toml",
     "audit": "yarn audit",
     "lint": "eslint src/**/*.js",
-    "test": "bun test",
+    "test": "DATA_DIR=./data/csv/ bun test",
     "test:watch": "bun test --watch"
   },
   "keywords": [

--- a/src/models/raceRiders/raceRiders.js
+++ b/src/models/raceRiders/raceRiders.js
@@ -1,3 +1,4 @@
+import { getDataDir } from "@utils/validation";
 import CSVdataModel from "@models/dataModel_csv";
 
 /**
@@ -20,7 +21,7 @@ export class RaceRiders extends CSVdataModel {
       bib: "number",
     };
     super(
-      `${process.env.DATA_DIR}/raceRiders.csv`,
+      `${getDataDir()}/raceRiders.csv`,
       ["raceUID", "bib"],
       fieldTypes,
     );

--- a/src/models/raceStageClassifications/classificationGeneral.js
+++ b/src/models/raceStageClassifications/classificationGeneral.js
@@ -1,4 +1,5 @@
 import { logError } from "@utils/logging";
+import { getDataDir } from "@utils/validation";
 import CSVdataModel from "@models/dataModel_csv";
 
 /**
@@ -27,7 +28,7 @@ export class ClassificationGeneral extends CSVdataModel {
       uCI: "number", // Matches toCamelCase("UCI") - see issue #341 for future standardization
     };
     super(
-      `${process.env.DATA_DIR}/raceStageClassificationGeneral.csv`,
+      `${getDataDir()}/raceStageClassificationGeneral.csv`,
       ["stageUID", "bib"],
       fieldTypes,
     );

--- a/src/models/raceStageClassifications/classificationMountains.js
+++ b/src/models/raceStageClassifications/classificationMountains.js
@@ -1,4 +1,5 @@
 import { logError } from "@utils/logging";
+import { getDataDir } from "@utils/validation";
 import CSVdataModel from "@models/dataModel_csv";
 
 /**
@@ -28,7 +29,7 @@ export class ClassificationMountains extends CSVdataModel {
       today: "number",
     };
     super(
-      `${process.env.DATA_DIR}/raceStageClassificationMountain.csv`,
+      `${getDataDir()}/raceStageClassificationMountain.csv`,
       ["stageUID", "bib"],
       fieldTypes,
     );

--- a/src/models/raceStageClassifications/classificationPoints.js
+++ b/src/models/raceStageClassifications/classificationPoints.js
@@ -1,4 +1,5 @@
 import { logError } from "@utils/logging";
+import { getDataDir } from "@utils/validation";
 import CSVdataModel from "@models/dataModel_csv";
 
 /**
@@ -28,7 +29,7 @@ export class ClassificationPoints extends CSVdataModel {
       today: "number",
     };
     super(
-      `${process.env.DATA_DIR}/raceStageClassificationPoints.csv`,
+      `${getDataDir()}/raceStageClassificationPoints.csv`,
       ["stageUID", "bib"],
       fieldTypes,
     );

--- a/src/models/raceStageClassifications/classificationTeam.js
+++ b/src/models/raceStageClassifications/classificationTeam.js
@@ -1,4 +1,5 @@
 import { logError } from "@utils/logging";
+import { getDataDir } from "@utils/validation";
 import CSVdataModel from "@models/dataModel_csv";
 
 /**
@@ -25,7 +26,7 @@ export class ClassificationTeam extends CSVdataModel {
       // bib: "number",
     };
     super(
-      `${process.env.DATA_DIR}/raceStageClassificationTeams.csv`,
+      `${getDataDir()}/raceStageClassificationTeams.csv`,
       ["stageUID", "team"],
       fieldTypes,
     );

--- a/src/models/raceStageClassifications/classificationYouth.js
+++ b/src/models/raceStageClassifications/classificationYouth.js
@@ -1,4 +1,5 @@
 import { logError } from "@utils/logging";
+import { getDataDir } from "@utils/validation";
 import CSVdataModel from "@models/dataModel_csv";
 
 /**
@@ -26,7 +27,7 @@ export class ClassificationYouth extends CSVdataModel {
       age: "number",
     };
     super(
-      `${process.env.DATA_DIR}/raceStageClassificationYouth.csv`,
+      `${getDataDir()}/raceStageClassificationYouth.csv`,
       ["stageUID", "bib"],
       fieldTypes,
     );

--- a/src/models/raceStages/raceStageLocationMountains.js
+++ b/src/models/raceStages/raceStageLocationMountains.js
@@ -1,3 +1,4 @@
+import { getDataDir } from "@utils/validation";
 import CSVdataModel from "@models/dataModel_csv";
 
 /**
@@ -22,7 +23,7 @@ export class RaceStageLocationMountains extends CSVdataModel {
       distance: "number",
     };
     super(
-      `${process.env.DATA_DIR}/raceStageLocationMountains.csv`,
+      `${getDataDir()}/raceStageLocationMountains.csv`,
       ["locationUID"],
       fieldTypes,
     );

--- a/src/models/raceStages/raceStageLocationMountainsResults.js
+++ b/src/models/raceStages/raceStageLocationMountainsResults.js
@@ -1,3 +1,4 @@
+import { getDataDir } from "@utils/validation";
 import CSVdataModel from "@models/dataModel_csv";
 
 /**
@@ -23,7 +24,7 @@ export class RaceStageLocationMountainsResults extends CSVdataModel {
       points: "number",
     };
     super(
-      `${process.env.DATA_DIR}/raceStageLocationMountainsResults.csv`,
+      `${getDataDir()}/raceStageLocationMountainsResults.csv`,
       ["locationUID", "bib"],
       fieldTypes,
     );

--- a/src/models/raceStages/raceStageLocationPoints.js
+++ b/src/models/raceStages/raceStageLocationPoints.js
@@ -1,3 +1,4 @@
+import { getDataDir } from "@utils/validation";
 import CSVdataModel from "@models/dataModel_csv";
 
 /**
@@ -22,7 +23,7 @@ export class RaceStageLocationPoints extends CSVdataModel {
       distance: "number",
     };
     super(
-      `${process.env.DATA_DIR}/raceStageLocationPoints.csv`,
+      `${getDataDir()}/raceStageLocationPoints.csv`,
       ["Location UID"],
       fieldTypes,
     );

--- a/src/models/raceStages/raceStageLocationPointsResults.js
+++ b/src/models/raceStages/raceStageLocationPointsResults.js
@@ -1,3 +1,4 @@
+import { getDataDir } from "@utils/validation";
 import CSVdataModel from "@models/dataModel_csv";
 
 /**
@@ -23,7 +24,7 @@ export class RaceStageLocationPointsResults extends CSVdataModel {
       points: "number",
     };
     super(
-      `${process.env.DATA_DIR}/raceStageLocationPointsResults.csv`,
+      `${getDataDir()}/raceStageLocationPointsResults.csv`,
       ["locationUID", "bib"],
       fieldTypes,
     );

--- a/src/models/raceStages/raceStageResults.js
+++ b/src/models/raceStages/raceStageResults.js
@@ -1,4 +1,5 @@
 import { logError } from "@utils/logging";
+import { getDataDir } from "@utils/validation";
 import CSVdataModel from "@models/dataModel_csv";
 
 /**
@@ -27,7 +28,7 @@ export class RaceStageResults extends CSVdataModel {
       points: "number",
     };
     super(
-      `${process.env.DATA_DIR}/raceStageResults.csv`,
+      `${getDataDir()}/raceStageResults.csv`,
       ["stageUID", "bib"],
       fieldTypes,
     );

--- a/src/models/raceStages/raceStages.js
+++ b/src/models/raceStages/raceStages.js
@@ -1,4 +1,5 @@
 import { logError } from "@utils/logging";
+import { getDataDir } from "@utils/validation";
 import CSVdataModel from "@models/dataModel_csv";
 
 /** @typedef {import('../@types/races').RaceStageModel} RaceStageModel*/
@@ -22,7 +23,7 @@ export class RaceStages extends CSVdataModel {
       verticalMeters: "number",
     };
     super(
-      `${process.env.DATA_DIR}/raceStages.csv`,
+      `${getDataDir()}/raceStages.csv`,
       ["stageUID", "raceUID"],
       fieldTypes,
     );

--- a/src/models/races/races.js
+++ b/src/models/races/races.js
@@ -1,4 +1,5 @@
 import { logOut } from "@utils/logging";
+import { getDataDir } from "@utils/validation";
 import CSVdataModel from "@models/dataModel_csv";
 
 /**
@@ -23,7 +24,7 @@ export class Races extends CSVdataModel {
       // endDate: "date",
     };
 
-    super(`${process.env.DATA_DIR}/races.csv`, ["raceUID"], fieldTypes);
+    super(`${getDataDir()}/races.csv`, ["raceUID"], fieldTypes);
     this.csvHeaders = [
       "Race UID",
       "Year",

--- a/src/models/riders/riders.js
+++ b/src/models/riders/riders.js
@@ -1,3 +1,4 @@
+import { getDataDir } from "@utils/validation";
 import CSVdataModel from "@models/dataModel_csv";
 
 /**
@@ -17,7 +18,7 @@ export class Riders extends CSVdataModel {
 
   constructor() {
     const fieldTypes = {};
-    super(`${process.env.DATA_DIR}/riders.csv`, ["Pcs Id"], fieldTypes);
+    super(`${getDataDir()}/riders.csv`, ["Pcs Id"], fieldTypes);
     this.csvHeaders = [
       "Pcs Id",
       "Surname",

--- a/src/models/teams/teams.js
+++ b/src/models/teams/teams.js
@@ -1,4 +1,5 @@
 import { logError } from "@utils/logging";
+import { getDataDir } from "@utils/validation";
 import CSVdataModel from "@models/dataModel_csv";
 
 /**
@@ -20,7 +21,7 @@ export class Teams extends CSVdataModel {
     const fieldTypes = {
       year: "number",
     };
-    super(`${process.env.DATA_DIR}/teams.csv`, ["Pcs Id"], fieldTypes);
+    super(`${getDataDir()}/teams.csv`, ["Pcs Id"], fieldTypes);
     this.csvHeaders = [
       "Year",
       "Pcs Id",

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -3,7 +3,7 @@
  * @throws {Error} If DATA_DIR environment variable is not defined.
  */
 export function validateDataDir() {
-  if (!process.env.DATA_DIR) {
+  if (!process.env.DATA_DIR.trim()) {
     throw new Error(
       "DATA_DIR environment variable is not defined. " +
         "Please set it in your .env file or environment. " +
@@ -19,5 +19,5 @@ export function validateDataDir() {
  */
 export function getDataDir() {
   validateDataDir();
-  return process.env.DATA_DIR;
+  return process.env.DATA_DIR.trim();
 }

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -1,0 +1,23 @@
+/**
+ * Validates that the DATA_DIR environment variable is defined.
+ * @throws {Error} If DATA_DIR environment variable is not defined.
+ */
+export function validateDataDir() {
+  if (!process.env.DATA_DIR) {
+    throw new Error(
+      "DATA_DIR environment variable is not defined. " +
+        "Please set it in your .env file or environment. " +
+        "Example: DATA_DIR=./data/csv/",
+    );
+  }
+}
+
+/**
+ * Gets the data directory path, validating it first.
+ * @returns {string} The DATA_DIR path.
+ * @throws {Error} If DATA_DIR environment variable is not defined.
+ */
+export function getDataDir() {
+  validateDataDir();
+  return process.env.DATA_DIR;
+}

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -3,7 +3,7 @@
  * @throws {Error} If DATA_DIR environment variable is not defined.
  */
 export function validateDataDir() {
-  if (!process.env.DATA_DIR.trim()) {
+  if (!process.env.DATA_DIR || !process.env.DATA_DIR.trim()) {
     throw new Error(
       "DATA_DIR environment variable is not defined. " +
         "Please set it in your .env file or environment. " +

--- a/test/server/controllers/healthController.test.js
+++ b/test/server/controllers/healthController.test.js
@@ -1,13 +1,33 @@
-import { describe, it, expect, beforeEach, afterEach, jest, mock } from "bun:test";
-import { getHealth } from "@server/controllers/healthController";
-import dataService from "@services/dataServiceInstance";
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  beforeEach,
+  afterEach,
+  jest,
+  mock,
+} from "bun:test";
 import fsSync from "fs";
 
-// Mock the logging module to prevent console errors in tests
+// Mock modules BEFORE any imports that depend on them
 mock.module("@utils/logging", () => ({
   logOut: jest.fn(),
   logError: jest.fn(),
 }));
+
+mock.module("@services/dataServiceInstance", () => ({
+  default: { isInitialized: true },
+}));
+
+// Dynamically import getHealth AFTER mocks are registered
+let getHealth;
+
+// Use beforeAll to import after mocks are set up
+beforeAll(async () => {
+  const module = await import("@server/controllers/healthController");
+  getHealth = module.getHealth;
+});
 
 describe("Health Controller", () => {
   let req;
@@ -16,9 +36,11 @@ describe("Health Controller", () => {
   let statusMock;
   let originalIsInitialized;
   let originalDataDir;
+  let dataService;
 
-  beforeEach(() => {
-    // Store original and set default to healthy
+  beforeEach(async () => {
+    // Get fresh reference to the mocked dataService
+    dataService = (await import("@services/dataServiceInstance")).default;
     originalIsInitialized = dataService.isInitialized;
     originalDataDir = process.env.DATA_DIR;
     dataService.isInitialized = true;
@@ -111,7 +133,7 @@ describe("Health Controller", () => {
       }
     });
 
-it("should include version from APP_VERSION env var", async () => {
+    it("should include version from APP_VERSION env var", async () => {
       const originalAppVersion = process.env.APP_VERSION;
       process.env.APP_VERSION = "1.2.3";
 
@@ -131,7 +153,9 @@ it("should include version from APP_VERSION env var", async () => {
       const originalAppVersion = process.env.APP_VERSION;
       delete process.env.APP_VERSION;
 
-const readFileSpy = jest.spyOn(fsSync, "readFileSync").mockReturnValue('{"version":"1.0.0"}');
+      const readFileSpy = jest
+        .spyOn(fsSync, "readFileSync")
+        .mockReturnValue('{"version":"1.0.0"}');
 
       await getHealth(req, res);
 
@@ -139,7 +163,8 @@ const readFileSpy = jest.spyOn(fsSync, "readFileSync").mockReturnValue('{"versio
       expect(response.version).toBe("1.0.0");
 
       readFileSpy.mockRestore();
-      if (originalAppVersion !== undefined) process.env.APP_VERSION = originalAppVersion;
+      if (originalAppVersion !== undefined)
+        process.env.APP_VERSION = originalAppVersion;
     });
 
     it("should return unknown when APP_VERSION unset and package.json read fails", async () => {
@@ -158,14 +183,17 @@ const readFileSpy = jest.spyOn(fsSync, "readFileSync").mockReturnValue('{"versio
       expect(response.version).toBe("unknown");
 
       readFileSpy.mockRestore();
-      if (originalAppVersion !== undefined) process.env.APP_VERSION = originalAppVersion;
+      if (originalAppVersion !== undefined)
+        process.env.APP_VERSION = originalAppVersion;
     });
 
     it("should return package version when APP_VERSION is empty string", async () => {
       const originalAppVersion = process.env.APP_VERSION;
       process.env.APP_VERSION = "";
 
-      const readFileSpy = jest.spyOn(fsSync, "readFileSync").mockReturnValue('{"version":"2.0.0"}');
+      const readFileSpy = jest
+        .spyOn(fsSync, "readFileSync")
+        .mockReturnValue('{"version":"2.0.0"}');
 
       await getHealth(req, res);
 


### PR DESCRIPTION
Models now throw a clear error when DATA_DIR is not defined instead of creating an 'undefined/' directory. This prevents silent failures when the environment variable is missing.

- Add validation utility in src/utils/validation.js
- Update all 14 model files to use getDataDir() helper
- Set DATA_DIR in test script for CI/CD compatibility

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated data directory configuration across the application to use unified validation, improving consistency and robustness.
  * Enhanced test configuration to explicitly specify the data directory path for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->