### PR TITLE
fix(template): correct prologue stage display with case-insensitive c…

### DIFF
--- a/src/client/components/page/title.js
+++ b/src/client/components/page/title.js
@@ -54,7 +54,7 @@ export function updatePageHeadings(state) {
     const stage = state.sportData.stages[state.selected.stage];
     if (!stage) return;
 
-    if (stage.stageType === "prologue") {
+    if (stage.stageType?.toLowerCase() === "prologue") {
       // Prologue
       updateTextSmooth(stageLabel, "Prologue");
       updateTextSmooth(stageType, "");

--- a/src/server/views/pages/race.ejs
+++ b/src/server/views/pages/race.ejs
@@ -19,9 +19,9 @@
       <span id="race-year"><%=  race.year %></span>
     </h1>
       <h2 id="stage-title">
-        <span id="stage-label" class="smooth-text"> <% if (stage?.stageType == "prologue") { %>Prologue<% } else { %>Stage<% } %></span>
+        <span id="stage-label" class="smooth-text"> <% if (stage?.stageType?.toLowerCase() == "prologue") { %>Prologue<% } else { %>Stage<% } %></span>
           <span id="stage-number" class="smooth-text"> <% if (stage?.stage !== 0) { %><%= stage?.stage %><% } %></span>
-          <span id="stage-type" class="smooth-text"> <% if (stage?.stageType && stage?.stageType != "prologue") { %>(<%= stage?.stageType %>)<% } %>
+          <span id="stage-type" class="smooth-text"> <% if (stage?.stageType && stage?.stageType?.toLowerCase() != "prologue") { %>(<%= stage?.stageType %>)<% } %>
           </span>
           <span id="stage-name">
             <span id="stage-departure" class="smooth-text"><%= stage?.departure %></span> to <span id="stage-arrival" class="smooth-text"><%= stage?.arrival %></span>


### PR DESCRIPTION
…heck

The prologue stage was displaying 'Stage 0 (Prologue)' instead of 'Prologue' because the stageType value in CSV data is 'Prologue' (capital P) but the template and client code checked for 'prologue' (lowercase).

Updated checks to use toLowerCase() for case-insensitive comparison:
- race.ejs: Server-side template initial render
- title.js: Client-side dynamic updates

Closes #297