### PR TITLE
feat(privacy): add privacy notice page

### DIFF
--- a/src/client/styles/base.css
+++ b/src/client/styles/base.css
@@ -61,3 +61,16 @@ a:hover {
 .is-hidden {
   display: none;
 }
+
+/* Prose content wrapper — constrains line length for readability.
+ * Optimal body text is 50–75 characters; 65ch is the midpoint.
+ * Use on any content-heavy page (about, privacy, legal, blog, etc.). */
+.content-prose {
+  width: 100%;
+  max-width: 65ch;
+}
+
+.content-prose table {
+  table-layout: fixed;
+  width: 100%;
+}

--- a/src/client/styles/base.css
+++ b/src/client/styles/base.css
@@ -68,9 +68,27 @@ a:hover {
 .content-prose {
   width: 100%;
   max-width: 65ch;
+  margin-top: 1.5rem;
 }
 
+/* Gap between sections */
+.content-prose > section + section {
+  margin-top: 2.5rem;
+}
+
+/* Gap between elements within sections */
+.content-prose section > * + * {
+  margin-top: 1.25rem;
+}
+
+/* Sub-headings need a touch more breathing room */
+.content-prose section > h3 {
+  margin-top: 1.75rem;
+}
+
+/* Tables */
 .content-prose table {
   table-layout: fixed;
   width: 100%;
+  margin-top: 1.5rem;
 }

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -85,6 +85,13 @@ async function setupRoutes(app) {
     // Mount view routes at the application level
     app.use("/", routesSeasonRaces);
 
+    // Privacy notice
+    app.get("/privacy", (req, res) => {
+      res.render("pages/privacy", {
+        title: "Privacy Notice",
+      });
+    });
+
     // Add 404 handler for undefined routes
     app.use((req, res) => {
       res.status(404).render("pages/error", {

--- a/src/server/views/organisms/footer.ejs
+++ b/src/server/views/organisms/footer.ejs
@@ -1,3 +1,3 @@
 <footer class="site-footer">
-  <p>&copy; <%= new Date().getFullYear() %> TourRankings</p>
+  <p>&copy; <%= new Date().getFullYear() %> TourRankings &middot; <a href="/privacy">Privacy Notice</a></p>
 </footer>

--- a/src/server/views/pages/privacy.ejs
+++ b/src/server/views/pages/privacy.ejs
@@ -127,7 +127,9 @@
         </li>
         <li>
           <strong>jsdelivr</strong> — serves the D3.js visualisation library.
-          It's a CDN, nothing more. No personal data is sent.
+          It's a CDN; browser requests may include network metadata (IP,
+          user-agent), but the app does not intentionally transmit any
+          app-level identifiers.
         </li>
       </ul>
     </section>

--- a/src/server/views/pages/privacy.ejs
+++ b/src/server/views/pages/privacy.ejs
@@ -10,114 +10,109 @@
 <body>
   <%- include('../organisms/header') %>
   <main>
-    <h1>Privacy Notice</h1>
-    <p><em>Last updated: May 2026</em></p>
+    <h1>Privacy</h1>
 
     <section>
-      <h2>What data we collect and why</h2>
-
-      <h3>Rider and team data</h3>
+      <h2>The short version</h2>
       <p>
-        TourRankings displays classification rankings for professional cycling races.
-        Rider names, nationalities, team affiliations, and race results are collected
-        from <a href="https://www.procyclingstats.com/">ProCyclingStats</a>, a publicly
-        available source. This data is processed under the legal basis of
-        <strong>legitimate interest</strong> — providing accurate sports statistics to
-        fans and analysts.
-      </p>
-
-      <h3>Feedback form</h3>
-      <p>
-        If you choose to submit feedback, we collect:
-      </p>
-      <ul>
-        <li>The message you write</li>
-        <li>The feedback category you select</li>
-        <li>The page URL and browser user agent (for debugging)</li>
-        <li>Your email address <strong>only if you voluntarily provide it</strong> (it is clearly marked as optional)</li>
-      </ul>
-      <p>
-        Feedback data is processed under the legal basis of <strong>consent</strong>.
-        You actively submit the form knowing what data is included.
+        This site shows race results for professional cycling tours.
+        We display rider names, nationalities, teams, and race data — the same
+        stuff you'd see on any race broadcast. We don't track you, we don't run
+        ads, and we don't sell anything. If you send us feedback, we'll keep
+        your message and, if you leave it, your email so we can reply. That's it.
       </p>
     </section>
 
     <section>
-      <h2>How we store your data</h2>
+      <h2>What data is on this site</h2>
+      <p>
+        All the race data — rider names, teams, results, classifications — is
+        public information about professional sports events. These riders are
+        public figures competing in public races. We display the same information
+        you'd find on any race result page or broadcast graphic.
+      </p>
+    </section>
+
+    <section>
+      <h2>What we collect from you</h2>
+      <p>
+        If you choose to use the feedback form on the site, we collect:
+      </p>
+      <ul>
+        <li>Your message and the feedback category you pick</li>
+        <li>The page you were on (so we know context)</li>
+        <li>Your email <em>only if you want to leave one</em> — it's optional and clearly marked as such</li>
+      </ul>
+      <p>
+        We don't require an account, we don't set tracking cookies, and we
+        don't monitor your browsing.
+      </p>
+    </section>
+
+    <section>
+      <h2>Where the data lives</h2>
       <table>
         <thead>
           <tr>
-            <th>Data</th>
-            <th>Storage</th>
-            <th>Retention</th>
+            <th>What</th>
+            <th>Where</th>
           </tr>
         </thead>
         <tbody>
           <tr>
-            <td>Rider and race data</td>
-            <td>CSV files (server-side)</td>
-            <td>Indefinitely — refreshed each season from public sources</td>
+            <td>Race and rider data</td>
+            <td>CSV files on our server</td>
           </tr>
           <tr>
-            <td>Feedback submissions</td>
-            <td>Google Sheets (private, accessed via service account)</td>
-            <td>Indefinitely until a deletion mechanism is implemented. To request deletion, contact us (see below).</td>
+            <td>Feedback messages</td>
+            <td>Private cloud storage (Google Sheets), accessed only by us</td>
           </tr>
           <tr>
             <td>Server logs</td>
-            <td>Ephemeral (container stdout, not persisted)</td>
-            <td>Not retained</td>
+            <td>Ephemeral — not stored or kept</td>
           </tr>
         </tbody>
       </table>
     </section>
 
     <section>
-      <h2>Third-party processors</h2>
+      <h2>Third-party services</h2>
+      <p>
+        A couple of external services help this site run:
+      </p>
       <ul>
         <li>
-          <strong>Google Sheets API</strong> — stores feedback submissions.
-          Data is transmitted via authenticated service account requests.
+          <strong>Google Sheets</strong> — stores feedback submissions
+          so we can read and respond to them. This is behind service
+          account authentication and not publicly accessible.
         </li>
         <li>
-          <strong>jsdelivr CDN</strong> — serves the D3.js visualisation library.
-          No personal data is shared.
+          <strong>jsdelivr</strong> — serves the D3.js visualisation library.
+          It's a CDN, nothing more. No personal data is sent.
         </li>
       </ul>
     </section>
 
     <section>
-      <h2>No tracking</h2>
+      <h2>No tracking, no ads</h2>
       <p>
-        TourRankings sets <strong>no cookies</strong> for tracking, analytics, or
-        advertising. We do not use Google Analytics, Facebook pixels, or any
-        third-party tracking services. The site does not collect browsing behaviour
-        or personalise content based on user profiles.
+        There are no analytics scripts, no tracking pixels, no advertising
+        cookies, and no profiling. We don't know who you are or what pages
+        you've visited. We just want to show you some good cycling rankings.
       </p>
     </section>
 
     <section>
       <h2>Your rights</h2>
-      <p>Under data protection law, you have the right to:</p>
-      <ul>
-        <li><strong>Access</strong> — request a copy of the personal data we hold about you</li>
-        <li><strong>Rectification</strong> — ask us to correct inaccurate data</li>
-        <li><strong>Erasure</strong> — request deletion of your feedback data</li>
-        <li><strong>Objection</strong> — object to our processing of your data</li>
-      </ul>
       <p>
-        To exercise any of these rights, please open a
-        <a href="https://github.com/mattay/tourrankings/issues">GitHub issue</a>
-        on the project repository. We will respond within 30 days.
+        You can ask us what data we hold about you, request corrections,
+        or ask us to delete your feedback. If you left an email with your
+        feedback, we can find it and remove it.
       </p>
-    </section>
-
-    <section>
-      <h2>Contact</h2>
       <p>
-        For privacy-related inquiries, open a
+        Just open a
         <a href="https://github.com/mattay/tourrankings/issues">GitHub issue</a>
-        on the project repository.
+        on the project repo and we'll sort it out.
       </p>
     </section>
   </main>

--- a/src/server/views/pages/privacy.ejs
+++ b/src/server/views/pages/privacy.ejs
@@ -152,7 +152,7 @@
       </p>
       <p>
         Drop us an email at
-        <a href="mailto:hello@tourrankings.com">hello@tourrankings.com</a>
+        <a href="mailto:hello@tour-ranking.com">hello@tour-ranking.com</a>
         and we'll sort it out.
       </p>
     </section>

--- a/src/server/views/pages/privacy.ejs
+++ b/src/server/views/pages/privacy.ejs
@@ -17,9 +17,12 @@
       <p>
         This site shows race results for professional cycling tours.
         We display rider names, nationalities, teams, and race data — the same
-        stuff you'd see on any race broadcast. We don't track you, we don't run
-        ads, and we don't sell anything. If you send us feedback, we'll keep
-        your message and, if you leave it, your email so we can reply. That's it.
+        stuff you'd see on any race broadcast. We set one cookie during your
+        visit so we can understand how people navigate the site, and we log
+        page requests anonymously so we can debug issues and see what features
+        actually get used. No ads, no selling, no third-party tracking.
+        If you send us feedback, we'll keep your message and, if you leave it,
+        your email so we can reply. That's it.
       </p>
     </section>
 
@@ -35,8 +38,38 @@
 
     <section>
       <h2>What we collect from you</h2>
+
+      <h3>Session cookie</h3>
       <p>
-        If you choose to use the feedback form on the site, we collect:
+        When you visit, we set a single cookie called <code>sid</code> with a
+        random identifier. It links your page views together within one visit
+        so we can see how people move through the site — for instance, whether
+        people check stage results before switching to the general
+        classification, or if they land on a race page and bounce.
+        The cookie has no personal data in it, it expires when you close your
+        browser, and we never share it with anyone.
+      </p>
+
+      <h3>Request logs</h3>
+      <p>
+        Every page request is logged to files on our server in NDJSON format.
+        Each entry records:
+      </p>
+      <ul>
+        <li>The page or API endpoint you visited</li>
+        <li>How long the response took</li>
+        <li>Your browser type (user agent string)</li>
+        <li>A <strong>hashed</strong> version of your IP address — it's one-way
+          (SHA-256), so we can't work out your IP from it</li>
+      </ul>
+      <p>
+        These logs help us debug problems and understand which features people
+        actually use. They're rotated regularly and not kept forever.
+      </p>
+
+      <h3>Feedback form</h3>
+      <p>
+        If you choose to use the feedback form, we collect:
       </p>
       <ul>
         <li>Your message and the feedback category you pick</li>
@@ -44,8 +77,8 @@
         <li>Your email <em>only if you want to leave one</em> — it's optional and clearly marked as such</li>
       </ul>
       <p>
-        We don't require an account, we don't set tracking cookies, and we
-        don't monitor your browsing.
+        We don't require an account and we don't share anything with third parties
+        for tracking or advertising.
       </p>
     </section>
 
@@ -68,8 +101,12 @@
             <td>Private cloud storage (Google Sheets), accessed only by us</td>
           </tr>
           <tr>
-            <td>Server logs</td>
-            <td>Ephemeral — not stored or kept</td>
+            <td>Request logs</td>
+            <td>NDJSON files on our server, rotated regularly and not kept indefinitely</td>
+          </tr>
+          <tr>
+            <td>Session cookie</td>
+            <td>Only in your browser — disappears when you close it</td>
           </tr>
         </tbody>
       </table>
@@ -94,11 +131,14 @@
     </section>
 
     <section>
-      <h2>No tracking, no ads</h2>
+      <h2>No ads, no third-party tracking</h2>
       <p>
-        There are no analytics scripts, no tracking pixels, no advertising
-        cookies, and no profiling. We don't know who you are or what pages
-        you've visited. We just want to show you some good cycling rankings.
+        There are no analytics scripts (no Google Analytics, no Facebook pixels),
+        no advertising cookies, and no profiling. The session cookie only links
+        page views within a single visit — it doesn't identify you and it doesn't
+        follow you across sessions or other sites. We don't know who you are,
+        we just want to understand whether the features we build are actually
+        useful. And we just want to show you some good cycling rankings.
       </p>
     </section>
 

--- a/src/server/views/pages/privacy.ejs
+++ b/src/server/views/pages/privacy.ejs
@@ -9,15 +9,6 @@
 </head>
 <body>
   <%- include('../organisms/header') %>
-  <style>
-    .content-prose {
-      max-width: 65ch;
-    }
-    .content-prose table {
-      table-layout: fixed;
-      width: 100%;
-    }
-  </style>
   <main>
     <h1>Privacy</h1>
     <div class="content-prose">

--- a/src/server/views/pages/privacy.ejs
+++ b/src/server/views/pages/privacy.ejs
@@ -60,8 +60,9 @@
         <li>The page or API endpoint you visited</li>
         <li>How long the response took</li>
         <li>Your browser type (user agent string)</li>
-        <li>A <strong>hashed</strong> version of your IP address — it's one-way
-          (SHA-256), so we can't work out your IP from it</li>
+        <li>A <strong>hashed</strong> version of your IP address — it's
+          pseudonymised with SHA-256 so your IP isn't stored in plain text,
+          but it may be re-identifiable in some circumstances</li>
       </ul>
       <p>
         These logs help us debug problems and understand which features people

--- a/src/server/views/pages/privacy.ejs
+++ b/src/server/views/pages/privacy.ejs
@@ -151,9 +151,9 @@
         feedback, we can find it and remove it.
       </p>
       <p>
-        Just open a
-        <a href="https://github.com/mattay/tourrankings/issues">GitHub issue</a>
-        on the project repo and we'll sort it out.
+        Drop us an email at
+        <a href="mailto:hello@tourrankings.com">hello@tourrankings.com</a>
+        and we'll sort it out.
       </p>
     </section>
     </div>

--- a/src/server/views/pages/privacy.ejs
+++ b/src/server/views/pages/privacy.ejs
@@ -1,0 +1,126 @@
+<!-- server/views/pages/privacy.ejs -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title><%= title %> | TourRankings</title>
+  <link rel="stylesheet" href="/css/base.css">
+</head>
+<body>
+  <%- include('../organisms/header') %>
+  <main>
+    <h1>Privacy Notice</h1>
+    <p><em>Last updated: May 2026</em></p>
+
+    <section>
+      <h2>What data we collect and why</h2>
+
+      <h3>Rider and team data</h3>
+      <p>
+        TourRankings displays classification rankings for professional cycling races.
+        Rider names, nationalities, team affiliations, and race results are collected
+        from <a href="https://www.procyclingstats.com/">ProCyclingStats</a>, a publicly
+        available source. This data is processed under the legal basis of
+        <strong>legitimate interest</strong> — providing accurate sports statistics to
+        fans and analysts.
+      </p>
+
+      <h3>Feedback form</h3>
+      <p>
+        If you choose to submit feedback, we collect:
+      </p>
+      <ul>
+        <li>The message you write</li>
+        <li>The feedback category you select</li>
+        <li>The page URL and browser user agent (for debugging)</li>
+        <li>Your email address <strong>only if you voluntarily provide it</strong> (it is clearly marked as optional)</li>
+      </ul>
+      <p>
+        Feedback data is processed under the legal basis of <strong>consent</strong>.
+        You actively submit the form knowing what data is included.
+      </p>
+    </section>
+
+    <section>
+      <h2>How we store your data</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Data</th>
+            <th>Storage</th>
+            <th>Retention</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Rider and race data</td>
+            <td>CSV files (server-side)</td>
+            <td>Indefinitely — refreshed each season from public sources</td>
+          </tr>
+          <tr>
+            <td>Feedback submissions</td>
+            <td>Google Sheets (private, accessed via service account)</td>
+            <td>Indefinitely until a deletion mechanism is implemented. To request deletion, contact us (see below).</td>
+          </tr>
+          <tr>
+            <td>Server logs</td>
+            <td>Ephemeral (container stdout, not persisted)</td>
+            <td>Not retained</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section>
+      <h2>Third-party processors</h2>
+      <ul>
+        <li>
+          <strong>Google Sheets API</strong> — stores feedback submissions.
+          Data is transmitted via authenticated service account requests.
+        </li>
+        <li>
+          <strong>jsdelivr CDN</strong> — serves the D3.js visualisation library.
+          No personal data is shared.
+        </li>
+      </ul>
+    </section>
+
+    <section>
+      <h2>No tracking</h2>
+      <p>
+        TourRankings sets <strong>no cookies</strong> for tracking, analytics, or
+        advertising. We do not use Google Analytics, Facebook pixels, or any
+        third-party tracking services. The site does not collect browsing behaviour
+        or personalise content based on user profiles.
+      </p>
+    </section>
+
+    <section>
+      <h2>Your rights</h2>
+      <p>Under data protection law, you have the right to:</p>
+      <ul>
+        <li><strong>Access</strong> — request a copy of the personal data we hold about you</li>
+        <li><strong>Rectification</strong> — ask us to correct inaccurate data</li>
+        <li><strong>Erasure</strong> — request deletion of your feedback data</li>
+        <li><strong>Objection</strong> — object to our processing of your data</li>
+      </ul>
+      <p>
+        To exercise any of these rights, please open a
+        <a href="https://github.com/mattay/tourrankings/issues">GitHub issue</a>
+        on the project repository. We will respond within 30 days.
+      </p>
+    </section>
+
+    <section>
+      <h2>Contact</h2>
+      <p>
+        For privacy-related inquiries, open a
+        <a href="https://github.com/mattay/tourrankings/issues">GitHub issue</a>
+        on the project repository.
+      </p>
+    </section>
+  </main>
+  <%- include('../organisms/footer') %>
+</body>
+</html>

--- a/src/server/views/pages/privacy.ejs
+++ b/src/server/views/pages/privacy.ejs
@@ -9,8 +9,18 @@
 </head>
 <body>
   <%- include('../organisms/header') %>
+  <style>
+    .content-prose {
+      max-width: 65ch;
+    }
+    .content-prose table {
+      table-layout: fixed;
+      width: 100%;
+    }
+  </style>
   <main>
     <h1>Privacy</h1>
+    <div class="content-prose">
 
     <section>
       <h2>The short version</h2>
@@ -155,6 +165,7 @@
         on the project repo and we'll sort it out.
       </p>
     </section>
+    </div>
   </main>
   <%- include('../organisms/footer') %>
 </body>


### PR DESCRIPTION
Adds a `/privacy` route with a plain-language privacy notice and links it from the footer.

Closes #384

## Changes

| File | Change |
|---|---|
| `src/server/index.js` | Adds `GET /privacy` route (inline render, no controller needed) |
| `src/server/views/pages/privacy.ejs` | **New** — privacy notice covering session cookie, request logs, feedback, third-party services, and user rights |
| `src/server/views/organisms/footer.ejs` | Adds `Privacy Notice` link next to copyright |
| `src/client/styles/base.css` | Adds `.content-prose` class (max-width: 65ch) for readable line length on content-heavy pages |

## Design decisions

- **Conversational tone** — not lawyer-dry, written for a cycling audience
- **Session cookie mentioned** — the `sid` cookie (issue #387) is documented so the privacy notice stays accurate
- **Request logging documented** — NDJSON logs with hashed IPs are explained honestly
- **No new CSS file** — `.content-prose` lives in base.css as a reusable typography constraint
- **No controller** — single static page rendered inline in `setupRoutes`
- **Contact via email** — placeholder `hello@tour-ranking.com` (swapped from GitHub issues to avoid exposing the project before launch)

## Related issues

- #384 — Original pitch for this work
- #385 — Remove unused `dateOfBirth` (separate branch)
- #386 — Replace Google Sheets with NDJSON (separate branch)
- #387 — Session cookie setup (separate branch)