### PR TITLE
fix(server): normalise date comparison to UTC for race temporal grouping

### DIFF
--- a/src/server/controllers/raceController.js
+++ b/src/server/controllers/raceController.js
@@ -17,6 +17,10 @@ import { dropValues } from "@utils/object.js";
 export function seasonRaces(season = null) {
   const today = new Date();
   const currentSeason = today.getFullYear();
+  // Normalise to UTC midnight so date comparisons are consistent regardless of
+  // server timezone. Without this, a server in Sydney (UTC+10) would consider
+  // the day "over" at 2 PM Italy time — before the race has finished.
+  today.setUTCHours(0, 0, 0, 0);
 
   if (!season || isNaN(season)) {
     season = currentSeason;


### PR DESCRIPTION
Without UTC normalisation, a server in Sydney (UTC+10) would consider the day 'over' at 2 PM Italy time — before a race has finished. This caused races on their final day to appear under 'Previous Races' instead of 'Current Races'.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Race date grouping now displays accurately across different server timezones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->