### PR TITLE
fix(ci): update flyctl to latest to fix deployment failures

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -122,9 +122,9 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
-      - uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1
+      - uses: superfly/flyctl-actions/setup-flyctl@master
         with:
-          version: 0.0.462
+          version: latest
 
       - name: Set deployment metadata
         run: |
@@ -158,9 +158,9 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
-      - uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1
+      - uses: superfly/flyctl-actions/setup-flyctl@master
         with:
-          version: 0.0.462
+          version: latest
 
       - name: Set APP_VERSION
         run: |


### PR DESCRIPTION
## Problem

Fly.io now requires `flyctl >= 0.2.71`. The CI/CD pipeline pins version `0.0.462` which is below the minimum due to Fly's versioning scheme change.

## Solution

Updated both deploy jobs in `ci-cd.yml` to use `flyctl@master` with `version: latest`.

## Error

```
flyctl version too old, must be at least 0.2.71
Error failed to fetch an image or build from source: error connecting to docker```
