### PR TITLE
fix(scraper): filter PCS startlist easter egg riders

### DIFF
--- a/src/scrappers/source/proCyclingStats/raceStartList.js
+++ b/src/scrappers/source/proCyclingStats/raceStartList.js
@@ -61,6 +61,76 @@ const DOM_SELECTORS = {
 };
 
 /**
+ * Detects PCS Easter Egg riders by checking for inline hiding styles.
+ * PCS uses CSS to hide injected riders (e.g., .slxl_iv li:nth-child(5)
+ * { height: 0px; }) but DOMParser doesn't compute CSS so we check
+ * inline style attributes directly.
+ *
+ * @param {HTMLElement} liElement - The <li> element for a rider.
+ * @returns {boolean} True if this element is hidden via inline styles.
+ */
+function isHiddenByInlineStyle(liElement) {
+  // Check inline styles that hide the element
+  const style = liElement.getAttribute("style") || "";
+  if (
+    style.includes("height: 0") ||
+    style.includes("height:0") ||
+    style.includes("display: none") ||
+    style.includes("display:none")
+  ) {
+    return true;
+  }
+
+  // Check the .bib child for inline hiding styles
+  const bibElement = liElement.querySelector(".bib");
+  const bibStyle = bibElement?.getAttribute("style") || "";
+  if (
+    bibStyle.includes("height: 0") ||
+    bibStyle.includes("height:0")
+  ) {
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * Removes PCS Easter Egg riders that share a bib number with a real rider.
+ * The easter egg is injected at every 5th position (indices 4, 9, 14, …)
+ * and duplicates the bib of the next real rider.
+ *
+ * @param {Array<{rider: ParsedRiderName, index: number}>} ridersWithIndex
+ *   Parsed riders with their original DOM index.
+ * @returns {Array<{rider: ParsedRiderName, index: number}>}
+ *   Riders with easter egg duplicates removed.
+ */
+function filterEasterEggDuplicates(ridersWithIndex) {
+  // Group riders by bib number
+  const bibGroups = new Map();
+  for (const entry of ridersWithIndex) {
+    if (entry.rider.bib == null) continue;
+    if (!bibGroups.has(entry.rider.bib)) {
+      bibGroups.set(entry.rider.bib, []);
+    }
+    bibGroups.get(entry.rider.bib).push(entry);
+  }
+
+  // Find duplicates to remove: the one at an easter egg position (5th, 10th…)
+  const indicesToRemove = new Set();
+  for (const [, group] of bibGroups) {
+    if (group.length <= 1) continue;
+    for (const entry of group) {
+      if ((entry.index + 1) % 5 === 0) {
+        indicesToRemove.add(entry.index);
+        break;
+      }
+    }
+  }
+
+  return ridersWithIndex.filter((e) => !indicesToRemove.has(e.index));
+}
+
+/**
  * Parses a team's title from a string.
  * @param {HTMLAnchorElement} htmlElement - The text containing the team's title.
  * @returns {ParsedTeamName} The parsed team title or an error message.
@@ -226,13 +296,28 @@ export function extractStartlistFromHtml(
         }
       }
 
-      // Riders
-      const riders = Array.from(
+      // Riders (filter out PCS easter egg riders hidden via CSS)
+      const riderElements = Array.from(
         teamElement.querySelectorAll(DOM_SELECTORS.teamRiders),
-      )
-        .map((rider) => parseTeamRider(rider))
-        .filter(Boolean)
-        .map((rider) => ({ year, ...rider }));
+      );
+
+      // Step 1: Remove elements hidden by inline styles
+      const visibleElements = riderElements.filter(
+        (li) => !isHiddenByInlineStyle(li),
+      );
+
+      // Step 2: Parse and track original DOM index
+      const ridersWithIndex = visibleElements
+        .map((li, index) => ({
+          rider: parseTeamRider(li),
+          // Map back to the original index within riderElements
+          index: riderElements.indexOf(li),
+        }))
+        .filter((e) => e.rider);
+
+      // Step 3: Remove easter egg duplicates (same bib at every-5th position)
+      const riders = filterEasterEggDuplicates(ridersWithIndex)
+        .map((e) => ({ year, ...e.rider }));
       if (riders.length === 0) {
         if (!quiet) {
           logError(

--- a/test/scraping/cycling/procyclingstats/fixtures/raceStartlist/easter-egg/raceStartList-2026-uae-tour-easter-egg.json
+++ b/test/scraping/cycling/procyclingstats/fixtures/raceStartlist/easter-egg/raceStartList-2026-uae-tour-easter-egg.json
@@ -1,0 +1,168 @@
+[
+  {
+    "year": 2026,
+    "pcsId": "uae-team-emirates-xrg-2026",
+    "name": "UAE Team Emirates - XRG",
+    "classification": "WT",
+    "pcsUrl": "https://www.procyclingstats.com/team/uae-team-emirates-xrg-2026",
+    "jerseyImageUrl": "https://www.procyclingstats.com/images/shirts/bx/eb/uae-team-emirates-xrg-2026.png",
+    "riders": [
+      {
+        "year": 2026,
+        "pcsId": "isaac-del-toro",
+        "pcsUrl": "https://www.procyclingstats.com/rider/isaac-del-toro",
+        "surname": "DEL TORO",
+        "firstNames": "Isaac",
+        "bib": 181,
+        "flag": "mx"
+      },
+      {
+        "year": 2026,
+        "pcsId": "rune-herregodts",
+        "pcsUrl": "https://www.procyclingstats.com/rider/rune-herregodts",
+        "surname": "HERREGODTS",
+        "firstNames": "Rune",
+        "bib": 182,
+        "flag": "be"
+      },
+      {
+        "year": 2026,
+        "pcsId": "juan-sebastian-molano",
+        "pcsUrl": "https://www.procyclingstats.com/rider/juan-sebastian-molano",
+        "surname": "MOLANO",
+        "firstNames": "Juan Sebastián",
+        "bib": 183,
+        "flag": "co"
+      },
+      {
+        "year": 2026,
+        "pcsId": "nils-politt",
+        "pcsUrl": "https://www.procyclingstats.com/rider/nils-politt",
+        "surname": "POLITT",
+        "firstNames": "Nils",
+        "bib": 184,
+        "flag": "de"
+      },
+      {
+        "year": 2026,
+        "pcsId": "kevin-vermaerke",
+        "pcsUrl": "https://www.procyclingstats.com/rider/kevin-vermaerke",
+        "surname": "VERMAERKE",
+        "firstNames": "Kevin",
+        "bib": 185,
+        "flag": "us"
+      },
+      {
+        "year": 2026,
+        "pcsId": "florian-vermeersch",
+        "pcsUrl": "https://www.procyclingstats.com/rider/florian-vermeersch",
+        "surname": "VERMEERSCH",
+        "firstNames": "Florian",
+        "bib": 186,
+        "flag": "be"
+      },
+      {
+        "year": 2026,
+        "pcsId": "adam-yates",
+        "pcsUrl": "https://www.procyclingstats.com/rider/adam-yates",
+        "surname": "YATES",
+        "firstNames": "Adam",
+        "bib": 187,
+        "flag": "gb"
+      }
+    ],
+    "staff": [
+      {
+        "year": 2026,
+        "pcsId": "andrej-hauptman",
+        "pcsUrl": "https://www.procyclingstats.com/staff/andrej-hauptman",
+        "surname": "HAUPTMAN",
+        "firstNames": "Andrej",
+        "role": "Directeur Sportif"
+      }
+    ]
+  },
+  {
+    "year": 2026,
+    "pcsId": "team-visma-lease-a-bike-2026",
+    "name": "Team Visma | Lease a Bike",
+    "classification": "WT",
+    "pcsUrl": "https://www.procyclingstats.com/team/team-visma-lease-a-bike-2026",
+    "jerseyImageUrl": "https://www.procyclingstats.com/images/shirts/bx/eb/team-visma-lease-a-bike-2026.png",
+    "riders": [
+      {
+        "year": 2026,
+        "pcsId": "wilco-kelderman",
+        "pcsUrl": "https://www.procyclingstats.com/rider/wilco-kelderman",
+        "surname": "KELDERMAN",
+        "firstNames": "Wilco",
+        "bib": 161,
+        "flag": "nl"
+      },
+      {
+        "year": 2026,
+        "pcsId": "owain-doull",
+        "pcsUrl": "https://www.procyclingstats.com/rider/owain-doull",
+        "surname": "DOULL",
+        "firstNames": "Owain",
+        "bib": 162,
+        "flag": "gb"
+      },
+      {
+        "year": 2026,
+        "pcsId": "tijmen-graat",
+        "pcsUrl": "https://www.procyclingstats.com/rider/tijmen-graat",
+        "surname": "GRAAT",
+        "firstNames": "Tijmen",
+        "bib": 163,
+        "flag": "nl"
+      },
+      {
+        "year": 2026,
+        "pcsId": "steven-kruijswijk",
+        "pcsUrl": "https://www.procyclingstats.com/rider/steven-kruijswijk",
+        "surname": "KRUIJSWIJK",
+        "firstNames": "Steven",
+        "bib": 164,
+        "flag": "nl"
+      },
+      {
+        "year": 2026,
+        "pcsId": "pietro-mattio",
+        "pcsUrl": "https://www.procyclingstats.com/rider/pietro-mattio",
+        "surname": "MATTIO",
+        "firstNames": "Pietro",
+        "bib": 165,
+        "flag": "it"
+      },
+      {
+        "year": 2026,
+        "pcsId": "jorgen-nordhagen",
+        "pcsUrl": "https://www.procyclingstats.com/rider/jorgen-nordhagen",
+        "surname": "NORDHAGEN",
+        "firstNames": "Jørgen",
+        "bib": 166,
+        "flag": "no"
+      },
+      {
+        "year": 2026,
+        "pcsId": "ben-tulett",
+        "pcsUrl": "https://www.procyclingstats.com/rider/ben-tulett",
+        "surname": "TULETT",
+        "firstNames": "Ben",
+        "bib": 167,
+        "flag": "gb"
+      }
+    ],
+    "staff": [
+      {
+        "year": 2026,
+        "pcsId": "gaetan-pons",
+        "pcsUrl": "https://www.procyclingstats.com/staff/gaetan-pons",
+        "surname": "PONS",
+        "firstNames": "Gaëtan",
+        "role": "Directeur Sportif"
+      }
+    ]
+  }
+]

--- a/test/scraping/cycling/procyclingstats/html/race-startlist-easter-egg/raceStartList-2026-uae-tour-easter-egg.html
+++ b/test/scraping/cycling/procyclingstats/html/race-startlist-easter-egg/raceStartList-2026-uae-tour-easter-egg.html
@@ -1,0 +1,21 @@
+<!DOCTYPE HTML><html>
+<head>
+<title>Startlist for UAE Tour 2026</title>
+<base href="https://www.procyclingstats.com/race.php" />
+<link rel="canonical" href="https://www.procyclingstats.com/race/uae-tour/2026/startlist" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<meta charset="utf-8">
+<link rel="stylesheet" type="text/css" href="v3_site_v99.css" />
+<style>
+.slxl_iv li:nth-child(5) { height: 0px; margin: 0; }
+.slxl_iv li:nth-child(5) .bib { height: 0; }
+</style>
+</head>
+<body>
+<div class="wrapper">
+<div class="page-content">
+<div class="selectCont"><select><option value="startlist">Startlist</option></select><div class="right fs11" style="padding: 3px; margin-right: 5px;"><b>15</b> riders</div><div class="clear"></div><ul class="startlist_v4"><li><div class="shirtCont"><a href="team/uae-team-emirates-xrg-2026"><img src="images/shirts/bx/eb/uae-team-emirates-xrg-2026.png" style="width: 100%;" /></a></div><div class="ridersCont"><div><a class="team" href="team/uae-team-emirates-xrg-2026">UAE Team Emirates - XRG (WT)</a><div class="clear"></div></div><ul class="slxl_iv"><li class=" "><span class="bib">181</span><span class="flag mx"></span><a href="rider/isaac-del-toro">DEL TORO Isaac</a></li><li class=" "><span class="bib">182</span><span class="flag be"></span><a href="rider/rune-herregodts">HERREGODTS Rune</a></li><li class=" "><span class="bib">183</span><span class="flag co"></span><a href="rider/juan-sebastian-molano">MOLANO Juan Sebastián</a></li><li class=" "><span class="bib">184</span><span class="flag de"></span><a href="rider/nils-politt">POLITT Nils</a></li><li class=" "><span class="bib">184</span><span class="flag si"></span><a href="rider/tadej-pogacar">POGAČAR Tadej</a></li><li class=" "><span class="bib">185</span><span class="flag us"></span><a href="rider/kevin-vermaerke">VERMAERKE Kevin</a></li><li class=" "><span class="bib">186</span><span class="flag be"></span><a href="rider/florian-vermeersch">VERMEERSCH Florian</a></li><li class=" "><span class="bib">187</span><span class="flag gb"></span><a href="rider/adam-yates">YATES Adam</a></li></ul><div class="dsCont"><b>DS</b> <a href="staff/andrej-hauptman">HAUPTMAN Andrej</a></div></div></li><li><div class="shirtCont"><a href="team/team-visma-lease-a-bike-2026"><img src="images/shirts/bx/eb/team-visma-lease-a-bike-2026.png" style="width: 100%;" /></a></div><div class="ridersCont"><div><a class="team" href="team/team-visma-lease-a-bike-2026">Team Visma | Lease a Bike (WT)</a><div class="clear"></div></div><ul><li class=" "><span class="bib">161</span><span class="flag nl"></span><a href="rider/wilco-kelderman">KELDERMAN Wilco</a></li><li class=" "><span class="bib">162</span><span class="flag gb"></span><a href="rider/owain-doull">DOULL Owain</a></li><li class=" "><span class="bib">163</span><span class="flag nl"></span><a href="rider/tijmen-graat">GRAAT Tijmen</a></li><li class=" "><span class="bib">164</span><span class="flag nl"></span><a href="rider/steven-kruijswijk">KRUIJSWIJK Steven</a></li><li class=" "><span class="bib">165</span><span class="flag it"></span><a href="rider/pietro-mattio">MATTIO Pietro</a></li><li class=" "><span class="bib">166</span><span class="flag no"></span><a href="rider/jorgen-nordhagen">NORDHAGEN Jørgen</a></li><li class=" "><span class="bib">167</span><span class="flag gb"></span><a href="rider/ben-tulett">TULETT Ben</a></li></ul><div class="dsCont"><b>DS</b> <a href="staff/gaetan-pons">PONS Gaëtan</a></div></div></li></ul></div>
+</div>
+</div>
+</body>
+</html>

--- a/test/scraping/cycling/procyclingstats/raceStartLists.test.js
+++ b/test/scraping/cycling/procyclingstats/raceStartLists.test.js
@@ -183,3 +183,53 @@ describe.each(STARTLIST_TEST_CASES)(
     });
   },
 );
+
+describe("Startlist [2026 UAE Tour] PCS Easter Egg filtering", () => {
+  let html, expectedResults, url;
+
+  beforeAll(async () => {
+    html = await Bun.file(
+      "test/scraping/cycling/procyclingstats/html/race-startlist-easter-egg/raceStartList-2026-uae-tour-easter-egg.html",
+    ).text();
+    expectedResults = await Bun.file(
+      "test/scraping/cycling/procyclingstats/fixtures/raceStartlist/easter-egg/raceStartList-2026-uae-tour-easter-egg.json",
+    ).json();
+    url =
+      "https://www.procyclingstats.com/race/uae-tour/2026/startlist";
+  });
+
+  test("Should filter out the easter egg rider (POGAČAR at position 5, duplicate bib 184)", async () => {
+    const startLists = extractStartlistFromHtml(html, 2026, url);
+    const uaeTeam = startLists.find(
+      (t) => t.pcsId === "uae-team-emirates-xrg-2026",
+    );
+    expect(uaeTeam).toBeDefined();
+    expect(uaeTeam.riders).toHaveLength(7);
+    expect(
+      uaeTeam.riders.find((r) => r.pcsId === "tadej-pogacar"),
+    ).toBeUndefined();
+    // POLITT (the real bib 184) should still be present
+    expect(
+      uaeTeam.riders.find((r) => r.pcsId === "nils-politt" && r.bib === 184),
+    ).toBeDefined();
+  });
+
+  test("Should not affect teams without an easter egg", async () => {
+    const startLists = extractStartlistFromHtml(html, 2026, url);
+    const vismaTeam = startLists.find(
+      (t) => t.pcsId === "team-visma-lease-a-bike-2026",
+    );
+    expect(vismaTeam).toBeDefined();
+    expect(vismaTeam.riders).toHaveLength(7);
+    expect(
+      vismaTeam.riders.find(
+        (r) => r.pcsId === "pietro-mattio" && r.bib === 165,
+      ),
+    ).toBeDefined();
+  });
+
+  test("Should match full expected output", async () => {
+    const startLists = extractStartlistFromHtml(html, 2026, url);
+    expect(startLists).toEqual(expectedResults);
+  });
+});


### PR DESCRIPTION
ProCyclingStats injects hidden riders into startlists at every 5th position (e.g., Pogačar into UAE Team Emirates). These are hidden via CSS (.slxl_iv li:nth-child(5) { height: 0px }) but DOMParser doesn't compute CSS, so they pollute scraped data with duplicate bib numbers.

Adds two detection layers:
1. Inline style check on <li> and .bib elements for height:0/display:none
2. Duplicate bib detection — the easter egg shares a bib with a real rider, so we remove the one at the every-5th position

Includes test fixture (UAE Tour 2026) with Pogačar injected at position 5 to verify filtering works without affecting clean teams.

Closes #PCS-easter-egg-startlist

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
* Fixed race startlist extraction to properly filter out hidden "PCS Easter Egg" riders that were previously appearing as duplicate entries with incorrect bib numbers, ensuring accurate startlist data is displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->