### PR TITLE
chore: remove stale TODO — unhandled rejection handling already implemented

### DIFF
--- a/src/server/index.js
+++ b/src/server/index.js
@@ -160,7 +160,6 @@ async function initializeServer() {
     await startServer(app);
 
     // Handle unhandled promise rejections globally
-    // TODO: Implement proper error handling and logging
     process.on("unhandledRejection", (reason, promise) => {
       const message =
         reason instanceof Error ? reason : new Error(String(reason));


### PR DESCRIPTION
Closes #224

The TODO at `src/server/index.js:163` asked to "implement proper error handling and logging" for unhandled promise rejections. This was already done — the handler uses `logError()` with structured logging, does graceful shutdown in production, and logs without crashing in development. The stale comment just needed removing.