### PR TITLE
fix(server): resolve real client IP behind Fly.io proxy

### DIFF
--- a/src/server/index.js
+++ b/src/server/index.js
@@ -26,6 +26,10 @@ const __dirname = dirname(__filename);
  */
 const app = express();
 
+// Trust Fly.io's edge proxy so req.ip reflects the real client IP
+// from X-Forwarded-For instead of the proxy connection address.
+app.set("trust proxy", true);
+
 /**
  * Sets up server middleware, view engine, and other configurations.
  * @param {import('express').Application} app - Express application instance.

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -28,7 +28,8 @@ const app = express();
 
 // Trust Fly.io's edge proxy so req.ip reflects the real client IP
 // from X-Forwarded-For instead of the proxy connection address.
-app.set("trust proxy", true);
+// A hop count of 1 limits trust to the immediate proxy layer.
+app.set("trust proxy", 1);
 
 /**
  * Sets up server middleware, view engine, and other configurations.

--- a/src/server/logging/request.js
+++ b/src/server/logging/request.js
@@ -70,6 +70,21 @@ function hashIP(ip) {
 }
 
 /**
+ * Resolves the original client IP address from Fly.io / proxy headers.
+ *
+ * Prefers Fly.io's `fly-client-ip` header, then falls back to Express's
+ * `req.ip` (requires `trust proxy`), then the socket address, then "unknown".
+ *
+ * @param {import('express').Request} req - Express request object
+ * @returns {string}
+ */
+export function getClientIp(req) {
+  return (
+    req.get("fly-client-ip") || req.ip || req.socket?.remoteAddress || "unknown"
+  );
+}
+
+/**
  * Logs an HTTP request by building a complete entry and writing to transports.
  * Fires after the response is sent — never blocks the client.
  *
@@ -99,7 +114,7 @@ export function logRequest(req, res, responseTimeMs, responseSizeBytes) {
       }
     })(),
     userAgent: req.get("user-agent") || "",
-    hashedIp: hashIP(req.ip || req.socket?.remoteAddress || "unknown"),
+    hashedIp: hashIP(getClientIp(req)),
     ...processMeta,
   };
 

--- a/test/server/logging/clientIp.test.js
+++ b/test/server/logging/clientIp.test.js
@@ -1,6 +1,5 @@
 import { describe, it, expect, jest, mock } from "bun:test";
 import crypto from "crypto";
-import { getClientIp } from "@server/logging/request";
 
 // Mock the file transport to capture log entries without writing files
 const mockWrite = jest.fn();
@@ -14,6 +13,9 @@ mock.module("@server/logging/transports/file", () => ({
   })),
   initializeFileTransport: jest.fn(),
 }));
+
+// Import after mocks are registered so the request module sees the mocked transport.
+import { getClientIp } from "@server/logging/request";
 
 describe("getClientIp", () => {
   it("prefers fly-client-ip header", () => {

--- a/test/server/logging/clientIp.test.js
+++ b/test/server/logging/clientIp.test.js
@@ -1,0 +1,153 @@
+import { describe, it, expect, jest, mock } from "bun:test";
+import crypto from "crypto";
+import { getClientIp } from "@server/logging/request";
+
+// Mock the file transport to capture log entries without writing files
+const mockWrite = jest.fn();
+const mockGetTarget = jest.fn(() => "access");
+
+mock.module("@server/logging/transports/file", () => ({
+  getFileTransport: jest.fn(() => ({
+    write: mockWrite,
+    getTarget: mockGetTarget,
+    enabled: true,
+  })),
+  initializeFileTransport: jest.fn(),
+}));
+
+describe("getClientIp", () => {
+  it("prefers fly-client-ip header", () => {
+    const req = {
+      ip: "10.0.0.1",
+      socket: { remoteAddress: "10.0.0.2" },
+      get: (header) =>
+        header === "fly-client-ip" ? "203.0.113.5" : undefined,
+    };
+    expect(getClientIp(req)).toBe("203.0.113.5");
+  });
+
+  it("falls back to req.ip", () => {
+    const req = {
+      ip: "192.168.1.1",
+      socket: { remoteAddress: "10.0.0.2" },
+      get: () => undefined,
+    };
+    expect(getClientIp(req)).toBe("192.168.1.1");
+  });
+
+  it("falls back to socket remoteAddress", () => {
+    const req = {
+      ip: undefined,
+      socket: { remoteAddress: "10.0.0.2" },
+      get: () => undefined,
+    };
+    expect(getClientIp(req)).toBe("10.0.0.2");
+  });
+
+  it("returns unknown when nothing is available", () => {
+    const req = {
+      ip: undefined,
+      socket: undefined,
+      get: () => undefined,
+    };
+    expect(getClientIp(req)).toBe("unknown");
+  });
+});
+
+describe("logRequest IP handling", () => {
+  it("should prefer fly-client-ip header for hashedIp", async () => {
+    const { logRequest } = await import("@server/logging/request");
+
+    const req = createMockReq({
+      "fly-client-ip": "203.0.113.1",
+    });
+    req.ip = "10.0.0.1";
+    const res = createMockRes();
+
+    logRequest(req, res, 10, 100);
+
+    const entry = mockWrite.mock.calls.at(-1)[1];
+    expect(entry.hashedIp).toBe(hash("203.0.113.1"));
+  });
+
+  it("should fall back to req.ip when fly-client-ip is absent", async () => {
+    const { logRequest } = await import("@server/logging/request");
+
+    const req = createMockReq();
+    req.ip = "192.168.1.1";
+    const res = createMockRes();
+
+    logRequest(req, res, 10, 100);
+
+    const entry = mockWrite.mock.calls.at(-1)[1];
+    expect(entry.hashedIp).toBe(hash("192.168.1.1"));
+  });
+
+  it("should fall back to socket remoteAddress", async () => {
+    const { logRequest } = await import("@server/logging/request");
+
+    const req = createMockReq();
+    req.ip = undefined;
+    req.socket = { remoteAddress: "10.0.0.2" };
+    const res = createMockRes();
+
+    logRequest(req, res, 10, 100);
+
+    const entry = mockWrite.mock.calls.at(-1)[1];
+    expect(entry.hashedIp).toBe(hash("10.0.0.2"));
+  });
+
+  it("should hash 'unknown' when no IP source is available", async () => {
+    const { logRequest } = await import("@server/logging/request");
+
+    const req = createMockReq();
+    req.ip = undefined;
+    req.socket = undefined;
+    const res = createMockRes();
+
+    logRequest(req, res, 10, 100);
+
+    const entry = mockWrite.mock.calls.at(-1)[1];
+    expect(entry.hashedIp).toBe(hash("unknown"));
+  });
+});
+
+function createMockReq(headers = {}) {
+  return {
+    method: "GET",
+    url: "/",
+    originalUrl: "/",
+    path: "/",
+    id: "test-request-id",
+    ip: "127.0.0.1",
+    socket: { remoteAddress: "127.0.0.1" },
+    get: (header) => {
+      if (header === "user-agent") return "test-agent";
+      return headers[header];
+    },
+  };
+}
+
+function createMockRes() {
+  return {
+    statusCode: 200,
+    socket: { bytesWritten: 100 },
+    status: function (code) {
+      this.statusCode = code;
+      return this;
+    },
+    json: function () {
+      return this;
+    },
+    send: function () {
+      return this;
+    },
+    on: function (event, callback) {
+      if (event === "finish") callback();
+    },
+  };
+}
+
+function hash(value) {
+  return crypto.createHash("sha256").update(value).digest("hex");
+}


### PR DESCRIPTION
Closes #405

## Changes

- Enables Express `trust proxy` in `src/server/index.js` so `req.ip` reflects the real client IP from `X-Forwarded-For` instead of the Fly proxy connection address.
- Adds `getClientIp()` helper in `src/server/logging/request.js` that prefers Fly.io's `fly-client-ip` header, then falls back to `req.ip`, then `req.socket.remoteAddress`, then `"unknown"`.
- Replaces the direct `req.ip` hash in `logRequest()` with `getClientIp(req)`.
- Adds dedicated `test/server/logging/clientIp.test.js` covering all fallback paths and integration with `logRequest()`.

## Why

On Fly.io, all requests arrive via `fly-proxy`, so `req.ip` and `req.socket.remoteAddress` return the proxy IP. This makes the recent GDPR-safe hashed IP logging useless for distinguishing visitors. Using the Fly-specific header (plus trust proxy) restores its value.

## Cross-reference

Related to #387 (session cookie for user journeys). That bet becomes more important as the reliable way to track user journeys, but this fix makes the existing IP-based logging correct again too.

## Testing

- `bun test test/server/logging/clientIp.test.js` passes
- Full suite: 244 pass, 0 fail

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved client IP address detection when requests pass through Fly.io proxy layers, ensuring more accurate request logging and analytics.

* **Tests**
  * Added test coverage for client IP resolution across multiple fallback sources and verified the resolved value is reflected in request logging output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->