### PR TITLE
feat(server): add session cookie for request log correlation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,11 @@ DATA_AUTO_REFRESH_INTERVAL=3600000
 # Security
 CORS_ORIGIN=https://tour-rankings.com
 
+# Analytics
+# Enable session cookie for request log correlation
+# Defaults to true in production and false in development
+# SESSION_TRACKING_ENABLED=true
+
 # File Watching
 # Enable watching CSV files for changes (near real-time updates when scraper runs)
 DATA_WATCH_FILES=TRUE

--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "tourrankings",
       "dependencies": {
         "compression": "^1.8.1",
+        "cookie-parser": "^1.4.7",
         "cors": "^2.8.6",
         "csv-parser": "^3.2.1",
         "docopt": "^0.6.2",
@@ -22,6 +23,7 @@
         "@eslint/js": "^10.0.1",
         "@playwright/test": "^1.60.0",
         "@types/bun": "^1.3.14",
+        "@types/cookie-parser": "^1.4.10",
         "@types/d3": "^7.4.3",
         "@types/express": "^5.0.6",
         "eslint": "^10.4.1",
@@ -83,6 +85,8 @@
     "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
     "@types/connect": ["@types/connect@3.4.38", "", { "dependencies": { "@types/node": "*" } }, "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug=="],
+
+    "@types/cookie-parser": ["@types/cookie-parser@1.4.10", "", { "peerDependencies": { "@types/express": "*" } }, "sha512-B4xqkqfZ8Wek+rCOeRxsjMS9OgvzebEzzLYw7NHYuvzb7IdxOkI0ZHGgeEBX4PUM7QGVvNSK60T3OvWj3YfBRg=="],
 
     "@types/d3": ["@types/d3@7.4.3", "", { "dependencies": { "@types/d3-array": "*", "@types/d3-axis": "*", "@types/d3-brush": "*", "@types/d3-chord": "*", "@types/d3-color": "*", "@types/d3-contour": "*", "@types/d3-delaunay": "*", "@types/d3-dispatch": "*", "@types/d3-drag": "*", "@types/d3-dsv": "*", "@types/d3-ease": "*", "@types/d3-fetch": "*", "@types/d3-force": "*", "@types/d3-format": "*", "@types/d3-geo": "*", "@types/d3-hierarchy": "*", "@types/d3-interpolate": "*", "@types/d3-path": "*", "@types/d3-polygon": "*", "@types/d3-quadtree": "*", "@types/d3-random": "*", "@types/d3-scale": "*", "@types/d3-scale-chromatic": "*", "@types/d3-selection": "*", "@types/d3-shape": "*", "@types/d3-time": "*", "@types/d3-time-format": "*", "@types/d3-timer": "*", "@types/d3-transition": "*", "@types/d3-zoom": "*" } }, "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww=="],
 
@@ -230,7 +234,9 @@
 
     "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
 
-    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
+    "cookie-parser": ["cookie-parser@1.4.7", "", { "dependencies": { "cookie": "0.7.2", "cookie-signature": "1.0.6" } }, "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw=="],
+
+    "cookie-signature": ["cookie-signature@1.0.6", "", {}, "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="],
 
     "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
 
@@ -649,6 +655,8 @@
     "editorconfig/commander": ["commander@10.0.1", "", {}, "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug=="],
 
     "editorconfig/minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
+
+    "express/cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
 
     "filelist/minimatch": ["minimatch@5.1.9", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw=="],
 

--- a/fly.dev.toml
+++ b/fly.dev.toml
@@ -21,6 +21,7 @@ DATA_AUTO_REFRESH = "true"
 DATA_AUTO_REFRESH_INTERVAL = "900000"  # 15 min - faster feedback in dev
 APP_VERSION = ""  # Injected by CI/CD during deployment
 CORS_ORIGIN = "https://tourrankings-dev.fly.dev"
+SESSION_TRACKING_ENABLED = "false"
 
 # File logging
 LOG_DIR = "/tourRanking/data/logs"

--- a/fly.prod.toml
+++ b/fly.prod.toml
@@ -21,6 +21,7 @@ DATA_AUTO_REFRESH = "true"
 DATA_AUTO_REFRESH_INTERVAL = "1800000"  # 30 min
 APP_VERSION = ""  # Injected by CI/CD during deployment
 CORS_ORIGIN = "https://tour-rankings.com"
+SESSION_TRACKING_ENABLED = "true"
 
 # File logging
 LOG_DIR = "/tourRanking/data/logs"

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "description": "",
   "dependencies": {
     "compression": "^1.8.1",
+    "cookie-parser": "^1.4.7",
     "cors": "^2.8.6",
     "csv-parser": "^3.2.1",
     "docopt": "^0.6.2",
@@ -50,12 +51,13 @@
     "@eslint/js": "^10.0.1",
     "@playwright/test": "^1.60.0",
     "@types/bun": "^1.3.14",
+    "@types/cookie-parser": "^1.4.10",
     "@types/d3": "^7.4.3",
     "@types/express": "^5.0.6",
     "eslint": "^10.4.1",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.6",
-    "globals": "^17.6.0",
+    "globals": "^17.6.0"
   },
   "engines": {
     "bun": ">=1.3.0"

--- a/src/server/config.js
+++ b/src/server/config.js
@@ -14,6 +14,12 @@ const __dirname = dirname(__fileName);
  */
 
 /**
+ * Session tracking configuration.
+ * @typedef {Object} SessionTrackingConfig
+ * @property {boolean} enabled - Whether session cookie tracking is enabled.
+ */
+
+/**
  * Application configuration object.
  *
  * @typedef {Object} Config
@@ -42,6 +48,7 @@ const __dirname = dirname(__fileName);
  * @property {Object} dataService - Data service configuration.
  * @property {boolean} dataService.autoRefresh - Enable auto-refresh.
  * @property {number} dataService.refreshInterval - Interval in milliseconds for auto-refresh.
+ * @property {SessionTrackingConfig} sessionTracking - Session tracking configuration.
  * @property {Object} logging - File logging configuration.
  * @property {boolean} logging.enabled - Whether file logging is enabled.
  * @property {LogTargetConfig} logging.access - Access log (pages, unknowns) config.
@@ -51,8 +58,10 @@ const __dirname = dirname(__fileName);
  */
 
 /** @type {Config} */
+const env = process.env.NODE_ENV || "development";
+
 const config = {
-  env: process.env.NODE_ENV || "development",
+  env,
   port: parseInt(process.env.PORT, 10) || 8080,
 
   // Path configuration
@@ -68,7 +77,9 @@ const config = {
   security: {
     cors: {
       origin: process.env.CORS_ORIGIN
-        ? process.env.CORS_ORIGIN.split(",").map((o) => o.trim()).filter(Boolean)
+        ? process.env.CORS_ORIGIN.split(",")
+            .map((o) => o.trim())
+            .filter(Boolean)
         : ["*"],
       methods: ["GET", "POST"],
     },
@@ -105,6 +116,14 @@ const config = {
     memoryWarningThresholdMB: parseNumber(
       process.env.HEALTH_MEMORY_WARNING_THRESHOLD_MB,
       400,
+    ),
+  },
+
+  // Session tracking configuration
+  sessionTracking: {
+    enabled: parseBool(
+      process.env.SESSION_TRACKING_ENABLED,
+      env === "production",
     ),
   },
 

--- a/src/server/logging/request.js
+++ b/src/server/logging/request.js
@@ -115,6 +115,7 @@ export function logRequest(req, res, responseTimeMs, responseSizeBytes) {
     })(),
     userAgent: req.get("user-agent") || "",
     hashedIp: hashIP(getClientIp(req)),
+    sessionId: req.cookies?.sid,
     ...processMeta,
   };
 

--- a/src/server/middleware/index.js
+++ b/src/server/middleware/index.js
@@ -1,8 +1,10 @@
 import express from "express";
 import compression from "compression";
+import cookieParser from "cookie-parser";
 import crypto from "crypto";
-import setupSecurityMiddleware from "./security";
-import errorHandler from "./errorHandler";
+import setupSecurityMiddleware from "@server/middleware/security";
+import errorHandler from "@server/middleware/errorHandler";
+import sessionCookieMiddleware from "@server/middleware/sessionCookie";
 import { logOut } from "@utils/logging";
 import { logRequest } from "@server/logging";
 import config from "@server/config";
@@ -11,6 +13,7 @@ import config from "@server/config";
  * Configures and applies all middleware to the provided Express app.
  *
  * - Logs all incoming requests with timestamp, method, and URL (dev only, excludes health).
+ * - Sets a session-only anonymous cookie for request log correlation when enabled.
  * - Writes structured NDJSON request logs to files.
  * - Parses JSON and URL-encoded request bodies.
  * - (Optionally) compresses responses using gzip (Brotli not supported in Bun as of 2025-03-17).
@@ -30,6 +33,12 @@ export default function setupMiddleware(app) {
       next();
     });
   }
+
+  // Parse cookies so req.cookies is available
+  app.use(cookieParser());
+
+  // Set a session-only anonymous cookie for request log correlation
+  app.use(sessionCookieMiddleware);
 
   /**
    * Request logging middleware for file-based NDJSON logging.

--- a/src/server/middleware/sessionCookie.js
+++ b/src/server/middleware/sessionCookie.js
@@ -1,0 +1,71 @@
+import crypto from "crypto";
+import config from "@server/config";
+
+/**
+ * Cookie name used for the anonymous session identifier.
+ * @type {string}
+ */
+export const SESSION_COOKIE_NAME = "sid";
+
+/**
+ * Options for the session cookie.
+ *
+ * - `httpOnly`: prevents JavaScript access.
+ * - `secure`: only sent over HTTPS.
+ * - `sameSite: "lax"`: sent with top-level navigations.
+ * - No `maxAge`: session cookie, expires when the browser closes.
+ *
+ * @type {import("express").CookieOptions}
+ */
+const SESSION_COOKIE_OPTIONS = {
+  httpOnly: true,
+  secure: true,
+  sameSite: "lax",
+};
+
+/**
+ * Generates a new anonymous session identifier.
+ *
+ * @returns {string} A random UUIDv4 session ID.
+ */
+export function generateSessionId() {
+  return crypto.randomUUID();
+}
+
+/**
+ * Middleware that sets a session-only anonymous identifier cookie.
+ *
+ * - Skips health check requests to avoid giving probes cookies.
+ * - Only runs when `SESSION_TRACKING_ENABLED` is true.
+ * - Assigns the generated ID to `req.cookies.sid` so it is available to
+ *   downstream middleware (e.g., request logging) on the same request.
+ *
+ * @param {import("express").Request} req - Express request object.
+ * @param {import("express").Response} res - Express response object.
+ * @param {import("express").NextFunction} next - Express next function.
+ * @returns {void}
+ */
+export default function sessionCookieMiddleware(req, res, next) {
+  if (!config.sessionTracking.enabled) {
+    next();
+    return;
+  }
+
+  const urlPath = req.originalUrl || req.url || "";
+  if (urlPath.startsWith("/health")) {
+    next();
+    return;
+  }
+
+  if (!req.cookies?.[SESSION_COOKIE_NAME]) {
+    const sessionId = generateSessionId();
+
+    // Make the ID available on this request for logging.
+    req.cookies = req.cookies || {};
+    req.cookies[SESSION_COOKIE_NAME] = sessionId;
+
+    res.cookie(SESSION_COOKIE_NAME, sessionId, SESSION_COOKIE_OPTIONS);
+  }
+
+  next();
+}

--- a/src/server/views/pages/privacy.ejs
+++ b/src/server/views/pages/privacy.ejs
@@ -60,6 +60,7 @@
         <li>The page or API endpoint you visited</li>
         <li>How long the response took</li>
         <li>Your browser type (user agent string)</li>
+        <li>The random session cookie ID, so we can link your page views within one visit</li>
         <li>A <strong>hashed</strong> version of your IP address — it's
           pseudonymised with SHA-256 so your IP isn't stored in plain text,
           but it may be re-identifiable in some circumstances</li>
@@ -139,10 +140,11 @@
       <p>
         There are no analytics scripts (no Google Analytics, no Facebook pixels),
         no advertising cookies, and no profiling. The session cookie only links
-        page views within a single visit — it doesn't identify you and it doesn't
-        follow you across sessions or other sites. We don't know who you are,
-        we just want to understand whether the features we build are actually
-        useful. And we just want to show you some good cycling rankings.
+        page views within a single visit and expires when you close your browser —
+        it doesn't identify you and it doesn't follow you across sessions or other
+        sites. We don't know who you are, we just want to understand whether the
+        features we build are actually useful. And we just want to show you some
+        good cycling rankings.
       </p>
     </section>
 

--- a/test/server/logging/requestLogging.test.js
+++ b/test/server/logging/requestLogging.test.js
@@ -269,10 +269,50 @@ describe("Request Logging Classification", () => {
 
       expect(entry.referrer).toBeUndefined();
     });
+
+    it("should include sessionId when a session cookie is present", async () => {
+      const { logRequest } = await import("@server/logging/request");
+
+      const req = createMockReq("/", "/", 200, undefined, {
+        sid: "test-session-id",
+      });
+      const res = createMockRes(200);
+
+      logRequest(req, res, 10, 100);
+
+      const lastWrite = mockWrite.mock.calls.at(-1);
+      const entry = lastWrite[1];
+
+      expect(entry.sessionId).toBe("test-session-id");
+    });
+
+    it("should omit sessionId when no session cookie is present", async () => {
+      const { logRequest } = await import("@server/logging/request");
+
+      const req = createMockReq("/", "/", 200);
+      const res = createMockRes(200);
+
+      logRequest(req, res, 10, 100);
+
+      const lastWrite = mockWrite.mock.calls.at(-1);
+      const entry = lastWrite[1];
+
+      expect(entry.sessionId).toBeUndefined();
+    });
   });
 });
 
-function createMockReq(originalUrl, url, statusCode, referrer) {
+/**
+ * Creates a mock Express request object for request logging tests.
+ *
+ * @param {string} originalUrl - The original URL of the request.
+ * @param {string} url - The URL path used for routing.
+ * @param {number} statusCode - The expected response status code.
+ * @param {string} [referrer] - Optional referrer header value.
+ * @param {Object} [cookies={}] - Optional cookies already present on the request.
+ * @returns {Object} A mock request object with method, URL, IP, cookies, and a get helper.
+ */
+function createMockReq(originalUrl, url, statusCode, referrer, cookies = {}) {
   return {
     method: "GET",
     url,
@@ -280,6 +320,7 @@ function createMockReq(originalUrl, url, statusCode, referrer) {
     path: url,
     id: "test-request-id",
     ip: "127.0.0.1",
+    cookies,
     get: (header) => {
       if (header === "user-agent") return "test-agent";
       if (header === "referrer") return referrer;
@@ -288,6 +329,12 @@ function createMockReq(originalUrl, url, statusCode, referrer) {
   };
 }
 
+/**
+ * Creates a mock Express response object for request logging tests.
+ *
+ * @param {number} statusCode - The response status code.
+ * @returns {Object} A mock response object with status, JSON, send, and finish-event helpers.
+ */
 function createMockRes(statusCode) {
   return {
     statusCode,

--- a/test/server/middleware/sessionCookie.test.js
+++ b/test/server/middleware/sessionCookie.test.js
@@ -1,0 +1,140 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  jest,
+  mock,
+} from "bun:test";
+
+/**
+ * Creates a fresh session cookie middleware import with the given config.
+ *
+ * @param {boolean} enabled - Whether session tracking is enabled in config.
+ * @returns {Promise<{ default: Function, SESSION_COOKIE_NAME: string }>}
+ */
+async function loadMiddleware(enabled) {
+  mock.module("@server/config", () => ({
+    default: {
+      env: "test",
+      sessionTracking: { enabled },
+    },
+  }));
+
+  return import("@server/middleware/sessionCookie");
+}
+
+/**
+ * Creates a mock Express request object for session cookie tests.
+ *
+ * @param {Object} [cookies={}] - Optional cookies already present on the request.
+ * @param {string} [originalUrl="/race/tour-de-france"] - The original URL of the request.
+ * @returns {Object} A mock request object with method, URL, cookies, and a get helper.
+ */
+function createMockReq(cookies = {}, originalUrl = "/race/tour-de-france") {
+  return {
+    method: "GET",
+    originalUrl,
+    url: originalUrl,
+    cookies,
+    get: jest.fn((header) => {
+      if (header === "user-agent") return "test-agent";
+      return undefined;
+    }),
+  };
+}
+
+/**
+ * Creates a mock Express response object for session cookie tests.
+ *
+ * @returns {{ cookie: import("bun:test").Mock<(...args: any[]) => void> }} A mock response object with a cookie method.
+ */
+function createMockRes() {
+  return {
+    cookie: jest.fn(),
+  };
+}
+
+/**
+ * Creates a mock Express next function for session cookie tests.
+ *
+ * @returns {import("bun:test").Mock<(...args: any[]) => void>} A jest mock function.
+ */
+function createMockNext() {
+  return jest.fn();
+}
+
+describe("sessionCookieMiddleware", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should set a session cookie when enabled and no cookie exists", async () => {
+    const { default: sessionCookieMiddleware, SESSION_COOKIE_NAME } =
+      await loadMiddleware(true);
+
+    const req = createMockReq();
+    const res = createMockRes();
+    const next = createMockNext();
+
+    sessionCookieMiddleware(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(res.cookie).toHaveBeenCalledTimes(1);
+    expect(res.cookie.mock.calls[0][0]).toBe(SESSION_COOKIE_NAME);
+
+    const cookieValue = res.cookie.mock.calls[0][1];
+    const cookieOptions = res.cookie.mock.calls[0][2];
+
+    expect(typeof cookieValue).toBe("string");
+    expect(cookieValue.length).toBeGreaterThan(0);
+    expect(req.cookies[SESSION_COOKIE_NAME]).toBe(cookieValue);
+    expect(cookieOptions).toEqual({
+      httpOnly: true,
+      secure: true,
+      sameSite: "lax",
+    });
+  });
+
+  it("should preserve an existing session cookie and not set a new one", async () => {
+    const { default: sessionCookieMiddleware, SESSION_COOKIE_NAME } =
+      await loadMiddleware(true);
+
+    const existingId = "existing-session-id";
+    const req = createMockReq({ [SESSION_COOKIE_NAME]: existingId });
+    const res = createMockRes();
+    const next = createMockNext();
+
+    sessionCookieMiddleware(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(res.cookie).not.toHaveBeenCalled();
+    expect(req.cookies[SESSION_COOKIE_NAME]).toBe(existingId);
+  });
+
+  it("should not set a cookie when session tracking is disabled", async () => {
+    const { default: sessionCookieMiddleware } = await loadMiddleware(false);
+
+    const req = createMockReq();
+    const res = createMockRes();
+    const next = createMockNext();
+
+    sessionCookieMiddleware(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(res.cookie).not.toHaveBeenCalled();
+  });
+
+  it("should not set a cookie for health check requests", async () => {
+    const { default: sessionCookieMiddleware } = await loadMiddleware(true);
+
+    const req = createMockReq({}, "/health/memory");
+    const res = createMockRes();
+    const next = createMockNext();
+
+    sessionCookieMiddleware(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(res.cookie).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Adds a session-only `sid` cookie so server request logs can correlate page views within a single visit.

### Changes
- New `SESSION_TRACKING_ENABLED` env flag (defaults to `true` in production, `false` in development)
- New `src/server/middleware/sessionCookie.js` middleware
- `cookie-parser` installed and mounted before the request logger
- `logRequest()` now includes `sessionId: req.cookies.sid`
- Health check requests are skipped to avoid giving probes cookies
- Privacy page updated to mention the session cookie ID is included in request logs
- `fly.prod.toml` and `fly.dev.toml` updated with explicit env values

### Why a cookie?
Client-side event tracking (#409) is the preferred long-term approach, but it isn't ready yet and we need to ship analytics first. The cookie is session-only, has no server-side state, and is gated by an env flag.

Closes #408


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional anonymous session-cookie tracking to help correlate page views within a visit. Session tracking is enabled by default in production and disabled in development.
  * Request logs now include a session ID when available; cookie assignment is skipped for health-check requests.

* **Documentation**
  * Updated the privacy policy to explain the session cookie, including that it expires when the browser is closed.

* **Tests**
  * Added/expanded coverage for session-cookie and request-log behaviour.

* **Chores**
  * Added cookie parsing dependency and related type support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->