### PR TITLE
fix(cron): harden scraper cron startup and add heartbeat

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
     ca-certificates \
     procps \
+    gosu \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean
 
@@ -71,7 +72,11 @@ RUN mkdir -p /tourRanking/data/csv /tourRanking/data/logs && \
 # Security
 # ============================================
 RUN chown -R bun:bun /tourRanking
-USER bun
+
+# Root-owned entrypoint so it can fix mounted volume permissions before
+# dropping privileges for the application processes.
+COPY --chown=root:root scripts/entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
 
 EXPOSE 8080
 
@@ -84,4 +89,5 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
 # ============================================
 # Startup
 # ============================================
-CMD ["bun", "start"]
+# Container starts as root; entrypoint fixes data volume ownership then drops to bun.
+CMD ["/usr/local/bin/entrypoint.sh"]

--- a/crontab
+++ b/crontab
@@ -1,2 +1,2 @@
 # Scrape for data every 45 minutes
-*/45 * * * * cd /tourRanking && bun scrape >> /dev/stdout 2>> /dev/stderr
+*/45 * * * * cd /tourRanking && /usr/local/bin/bun scrape

--- a/fly.dev.toml
+++ b/fly.dev.toml
@@ -40,7 +40,7 @@ source = "dev_data_volume"
 destination = "/tourRanking/data"
 
 [processes]
-webserver = "sh -c 'supercronic -passthrough-logs /tourRanking/crontab & exec bun start'"
+webserver = "/usr/local/bin/entrypoint.sh"
 
 [http_service]
 processes = ["webserver"]

--- a/fly.prod.toml
+++ b/fly.prod.toml
@@ -40,7 +40,7 @@ source = "data_volume"
 destination = "/tourRanking/data"
 
 [processes]
-webserver = "sh -c 'supercronic -passthrough-logs /tourRanking/crontab & exec bun start'"
+webserver = "/usr/local/bin/entrypoint.sh"
 
 [http_service]
 processes = ["webserver"]

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -e
+
+# Entrypoint for the Fly.io container.
+#
+# Fly mounts the persistent volume over /tourRanking/data at runtime, hiding
+# the directories and permissions created in the image. This script runs as
+# root briefly to ensure the required subdirectories exist and are writable by
+# the app user, then drops privileges and starts cron + the web server.
+
+DATA_DIR=/tourRanking/data
+
+mkdir -p "$DATA_DIR/csv" "$DATA_DIR/html" "$DATA_DIR/logs"
+chown -R bun:bun "$DATA_DIR"
+
+# Start supercronic and the webserver as the bun user.
+exec gosu bun sh -c 'supercronic -passthrough-logs /tourRanking/crontab & exec bun start'

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -14,4 +14,16 @@ mkdir -p "$DATA_DIR/csv" "$DATA_DIR/html" "$DATA_DIR/logs"
 chown -R bun:bun "$DATA_DIR"
 
 # Start supercronic and the webserver as the bun user.
-exec gosu bun sh -c 'supercronic -passthrough-logs /tourRanking/crontab & exec bun start'
+# Wait for either process to exit; if one fails, kill the other and propagate
+# the exit status so the container is restarted.
+exec gosu bun bash -c '
+  supercronic -passthrough-logs /tourRanking/crontab &
+  cron_pid=$!
+  bun start &
+  server_pid=$!
+  wait -n
+  exit_code=$?
+  kill "$cron_pid" "$server_pid" 2>/dev/null || true
+  wait
+  exit $exit_code
+'

--- a/src/scrappers/scrape_proCyclingStats.js
+++ b/src/scrappers/scrape_proCyclingStats.js
@@ -72,6 +72,7 @@ import path from "path";
  * Contains only an ISO timestamp and a label — no PII.
  *
  * @param {string} label - "started" or "completed"
+ * @returns {void}
  */
 function writeHeartbeat(label) {
   try {
@@ -80,6 +81,7 @@ function writeHeartbeat(label) {
     fs.writeFileSync(heartbeatPath, `${new Date().toISOString()} ${label}\n`);
   } catch (error) {
     logError("Scraper", "Failed to write heartbeat", error);
+    throw error;
   }
 }
 // Scrape

--- a/src/scrappers/scrape_proCyclingStats.js
+++ b/src/scrappers/scrape_proCyclingStats.js
@@ -64,6 +64,24 @@ import { generateId } from "@cycling/idGenerator";
 import { logError, logOut } from "@utils/logging";
 import { parseBool, parseNumber } from "@utils/sanity";
 import { logMemoryUsage } from "@utils/memory";
+import fs from "fs";
+import path from "path";
+
+/**
+ * Write a small heartbeat file so we can verify the cron job fired.
+ * Contains only an ISO timestamp and a label — no PII.
+ *
+ * @param {string} label - "started" or "completed"
+ */
+function writeHeartbeat(label) {
+  try {
+    const dataDir = process.env.DATA_DIR || "./data/csv";
+    const heartbeatPath = path.join(dataDir, "..", "last-scrape.txt");
+    fs.writeFileSync(heartbeatPath, `${new Date().toISOString()} ${label}\n`);
+  } catch (error) {
+    logError("Scraper", "Failed to write heartbeat", error);
+  }
+}
 // Scrape
 import {
   collectWorldTourRaces,
@@ -629,6 +647,8 @@ async function updateStageResults(models, year) {
  */
 async function main() {
   try {
+    writeHeartbeat("started");
+
     // Data Models
     // TODO -> utilse dataService
     const models = {
@@ -728,6 +748,8 @@ async function main() {
         logOut("Main", "[FEATURE DISABLED] Update results", "warn");
       }
     }
+
+    writeHeartbeat("completed");
   } catch (error) {
     // Catch-all for any errors not handled above
     logError("Main", "Fatal error", error);


### PR DESCRIPTION
- Use absolute bun path in crontab and remove fragile stdout/stderr redirect
- Add root entrypoint script that ensures data volume dirs are writable before dropping to bun
- Use entrypoint in fly prod/dev process commands
- Keep prod machine awake so cron can run
- Write last-scrape heartbeat file on each scraper run

Closes #415

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Scraper now emits status heartbeat to track execution progress and completion.

* **Chores**
  * Enhanced container startup process with improved file permission management for mounted volumes.
  * Simplified application launch workflow across development and production environments.
  * Updated scheduled task invocation method for better compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->