### PR TITLE
fix(entrypoint): forward SIGTERM/SIGINT to child processes

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -21,9 +21,15 @@ exec gosu bun bash -c '
   cron_pid=$!
   bun start &
   server_pid=$!
+
+  cleanup() {
+    kill "$cron_pid" "$server_pid" 2>/dev/null || true
+    wait
+  }
+  trap cleanup TERM INT
+
   wait -n
   exit_code=$?
-  kill "$cron_pid" "$server_pid" 2>/dev/null || true
-  wait
+  cleanup
   exit $exit_code
 '


### PR DESCRIPTION
Closes #420

Depends on #416.

## Summary
Forwards shutdown signals to both `supercronic` and `bun start` so Fly.io can stop the machine cleanly.

## Changes
- Added a `cleanup` function and `trap cleanup TERM INT` inside the bash command.
- The trap kills both background PIDs and waits for them before exiting.

## Notes
Without this, a `SIGTERM` from Fly could leave supercronic or the web server running until the hard kill.
