### PR TITLE
feat(health): report last scraper heartbeat in /health

### DIFF
--- a/src/server/controllers/health/index.js
+++ b/src/server/controllers/health/index.js
@@ -1,6 +1,7 @@
 export { statusOfDataService } from "./data-service";
 export { statusOfFilesystem } from "./file-system";
 export { statusOfMemory } from "./memory";
+export { statusOfLastScrape } from "./last-scrape";
 
 /**
  * @typedef {import('./types').MemoryCheckStatus}    MemoryCheckStatus
@@ -8,4 +9,6 @@ export { statusOfMemory } from "./memory";
  * @typedef {import('./types').MemoryCheckResult}    MemoryCheckResult
  * @typedef {import('./types').DataServiceCheckStatus} DataServiceCheckStatus
  * @typedef {import('./types').FilesystemCheckStatus}  FilesystemCheckStatus
+ * @typedef {import('./types').LastScrapeCheckStatus}  LastScrapeCheckStatus
+ * @typedef {import('./types').LastScrapeCheckResult}  LastScrapeCheckResult
  */

--- a/src/server/controllers/health/last-scrape.js
+++ b/src/server/controllers/health/last-scrape.js
@@ -1,0 +1,54 @@
+import fs from "fs/promises";
+import path from "path";
+import config from "@server/config";
+import { logError } from "@utils/logging";
+
+/**
+ * @typedef {"healthy" | "unhealthy" | "error"} LastScrapeCheckStatus
+ */
+
+/**
+ * @typedef {Object} LastScrapeCheckResult
+ * @property {LastScrapeCheckStatus} status
+ * @property {string|null} lastRunAt - ISO timestamp of the last scrape, or null
+ */
+
+const DEFAULT_THRESHOLD_MS = 2 * 60 * 60 * 1000; // 2 hours
+
+/**
+ * Checks whether the scraper cron has run recently by reading its heartbeat file.
+ *
+ * @returns {Promise<LastScrapeCheckResult>}
+ *   - `"healthy"`   — heartbeat exists and is within the threshold
+ *   - `"unhealthy"` — heartbeat exists but is older than the threshold
+ *   - `"error"`     — heartbeat is missing or unreadable
+ */
+export async function statusOfLastScrape() {
+  const dataDir = process.env.DATA_DIR || config.dataService.dataDir;
+  const heartbeatPath = path.join(dataDir, "..", "last-scrape.txt");
+
+  try {
+    const content = await fs.readFile(heartbeatPath, "utf8");
+    const firstLine = content.split("\n")[0];
+    const timestamp = firstLine.split(" ")[0];
+    const lastRunAt = new Date(timestamp);
+
+    if (isNaN(lastRunAt.getTime())) {
+      return { status: "error", lastRunAt: null };
+    }
+
+    const ageMs = Date.now() - lastRunAt.getTime();
+    const thresholdMs =
+      parseInt(process.env.SCRAPER_HEARTBEAT_THRESHOLD_MS, 10) ||
+      DEFAULT_THRESHOLD_MS;
+    const status = ageMs <= thresholdMs ? "healthy" : "unhealthy";
+
+    return { status, lastRunAt: lastRunAt.toISOString() };
+  } catch (error) {
+    if (error.code === "ENOENT") {
+      return { status: "error", lastRunAt: null };
+    }
+    logError("Health", "Last scrape check failed", error);
+    return { status: "error", lastRunAt: null };
+  }
+}

--- a/src/server/controllers/health/types.js
+++ b/src/server/controllers/health/types.js
@@ -22,4 +22,14 @@
  * @typedef {"healthy" | "unhealthy" | "error"} FilesystemCheckStatus
  */
 
+/**
+ * @typedef {"healthy" | "unhealthy" | "error"} LastScrapeCheckStatus
+ */
+
+/**
+ * @typedef {Object} LastScrapeCheckResult
+ * @property {LastScrapeCheckStatus} status
+ * @property {string|null} lastRunAt
+ */
+
 export {};

--- a/src/server/controllers/healthController.js
+++ b/src/server/controllers/healthController.js
@@ -8,6 +8,7 @@ import {
   statusOfDataService,
   statusOfMemory,
   statusOfFilesystem,
+  statusOfLastScrape,
 } from "@server/controllers/health";
 
 /**
@@ -26,6 +27,8 @@ import {
  * @property {import('@server/controllers/health').DataServiceCheckStatus}  checks.dataService
  * @property {import('@server/controllers/health').FilesystemCheckStatus}   checks.filesystem
  * @property {import('@server/controllers/health').MemoryCheckStatus}       checks.memory
+ * @property {import('@server/controllers/health').LastScrapeCheckStatus}   checks.lastScrape
+ * @property {string|null}         lastScrapeAt  - ISO timestamp of the last scraper heartbeat, or null
  * @property {string}              responseTime  - Total time taken to run all checks (e.g. `"12ms"`)
  */
 
@@ -60,13 +63,18 @@ export async function getHealth(req, res, next) {
   const startTime = Date.now();
 
   try {
-    const [dataService, filesystem, { memoryCheck: memory, memoryUsage }] =
-      await Promise.all([
-        statusOfDataService(),
-        statusOfFilesystem(),
-        statusOfMemory(),
-      ]);
-    const checks = { dataService, filesystem, memory };
+    const [
+      dataService,
+      filesystem,
+      { memoryCheck: memory, memoryUsage },
+      lastScrape,
+    ] = await Promise.all([
+      statusOfDataService(),
+      statusOfFilesystem(),
+      statusOfMemory(),
+      statusOfLastScrape(),
+    ]);
+    const checks = { dataService, filesystem, memory, lastScrape: lastScrape.status };
     const status = deriveOverallStatus(Object.values(checks));
 
     /** @type {HealthCheckResponse} */
@@ -78,6 +86,7 @@ export async function getHealth(req, res, next) {
       version: getAppVersion(),
       memoryUsage,
       checks,
+      lastScrapeAt: lastScrape.lastRunAt,
       responseTime: `${Date.now() - startTime}ms`,
     };
 

--- a/test/server/controllers/healthController.test.js
+++ b/test/server/controllers/healthController.test.js
@@ -20,6 +20,13 @@ mock.module("@services/dataServiceInstance", () => ({
   default: { isInitialized: true },
 }));
 
+mock.module("@server/controllers/health/last-scrape", () => ({
+  statusOfLastScrape: jest.fn().mockResolvedValue({
+    status: "healthy",
+    lastRunAt: new Date().toISOString(),
+  }),
+}));
+
 // Dynamically import getHealth AFTER mocks are registered
 let getHealth;
 

--- a/test/server/routes/routesHealth.test.js
+++ b/test/server/routes/routesHealth.test.js
@@ -24,6 +24,13 @@ mock.module("@services/dataServiceInstance", () => ({
   default: mockDataService,
 }));
 
+mock.module("@server/controllers/health/last-scrape", () => ({
+  statusOfLastScrape: jest.fn().mockResolvedValue({
+    status: "healthy",
+    lastRunAt: new Date().toISOString(),
+  }),
+}));
+
 describe("Health Routes", () => {
   let app;
   let originalIsInitialized;


### PR DESCRIPTION
Closes #423

Depends on #416.

## Summary
Adds a cron-freshness check to `/health` so deploys can be verified by looking at the scraper heartbeat instead of manually checking logs.

## Changes
- New `src/server/controllers/health/last-scrape.js` reads `/tourRanking/data/last-scrape.txt`.
- Returns `"healthy"` if the heartbeat is within 2 hours, `"unhealthy"` if older, `"error"` if missing.
- `GET /health` now includes `checks.lastScrape` and `lastScrapeAt`.
- Existing tests mock the new check to remain deterministic.

## Verification
- `bun run lint` ✅
- `bun test` ✅ (250 tests)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added scraper heartbeat monitoring to the health check endpoint. The system now tracks whether the scraper has run recently and reports its status as healthy, unhealthy, or errored, along with the timestamp of the last successful run. Configurable threshold controls how recently the scraper must have run.

* **Tests**
  * Updated health check tests to cover the new scraper monitoring functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->