### PR TITLE
feat(backup): add Fly.io data volume backup script

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -160,6 +160,19 @@ docker compose -f docker-compose.test.yml build --no-cache
 - Fly.io: Data stored in volumes
 - Volumes must be created before first deploy
 
+### Backups
+Before major changes or releases, back up the Fly.io data volume:
+
+```bash
+# Production backup
+scripts/backup-data.sh
+
+# Development backup
+scripts/backup-data.sh dev
+```
+
+This produces a timestamped tarball (`tourrankings-<env>-backup-<timestamp>.tar.gz`) containing `/tourRanking/data`.
+
 ## Deployment Checklist
 
 ### Before Deploying to Fly.io Dev

--- a/scripts/backup-data.sh
+++ b/scripts/backup-data.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -e
+
+# Backup the Fly.io data volume to a local tarball.
+#
+# Usage:
+#   scripts/backup-data.sh         # back up production
+#   scripts/backup-data.sh dev     # back up development
+#
+# Requires the Fly.io CLI (flyctl) and access to the app.
+
+ENV=${1:-prod}
+
+case "$ENV" in
+  dev)
+    CONFIG="fly.dev.toml"
+    ;;
+  prod)
+    CONFIG="fly.prod.toml"
+    ;;
+  *)
+    echo "Usage: $0 [dev|prod]"
+    exit 1
+    ;;
+esac
+
+TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+OUTFILE="tourrankings-${ENV}-backup-${TIMESTAMP}.tar.gz"
+
+echo "Backing up /tourRanking/data from ${ENV} to ${OUTFILE}..."
+fly ssh console --config "${CONFIG}" -C "tar czf - /tourRanking/data" > "${OUTFILE}"
+echo "Backup complete: ${OUTFILE}"


### PR DESCRIPTION
Closes #424

## Summary
Adds a simple, documented backup process for the Fly.io data volume before releases or major changes.

## Changes
- New `scripts/backup-data.sh` creates a timestamped tarball of `/tourRanking/data`.
- Supports `dev` and `prod` environments.
- Added backup instructions to `DEPLOYMENT.md` under the Data Persistence section.

## Usage
```bash
scripts/backup-data.sh      # production
scripts/backup-data.sh dev  # development
```

## Verification
- Shell syntax check: `bash -n scripts/backup-data.sh` ✅
- No JS changes; lint/tests unaffected.
