### PR TITLE
fix(ci): correct changelog install syntax and add deploy retries

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -135,11 +135,16 @@ jobs:
 
       - name: Deploy to development
         run: |
-          flyctl deploy --config fly.dev.toml --remote-only \
-            --env BRANCH_NAME=${{ env.BRANCH_NAME }} \
-            --env DEPLOYMENT_TIME=${{ env.DEPLOYMENT_TIME }} \
-            --env COMMIT_SHA=${{ env.COMMIT_SHA }} \
-            --env APP_VERSION=${{ env.APP_VERSION }}
+          for i in 1 2 3; do
+            flyctl deploy --config fly.dev.toml --remote-only \
+              --env BRANCH_NAME=${{ env.BRANCH_NAME }} \
+              --env DEPLOYMENT_TIME=${{ env.DEPLOYMENT_TIME }} \
+              --env COMMIT_SHA=${{ env.COMMIT_SHA }} \
+              --env APP_VERSION=${{ env.APP_VERSION }} && exit 0
+            echo "Deploy attempt $i failed. Retrying in 30s..."
+            sleep 30
+          done
+          exit 1
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_DEPLOY_TOKEN }}
 
@@ -168,9 +173,14 @@ jobs:
 
       - name: Deploy to production
         run: |
-          flyctl deploy --config fly.prod.toml --remote-only \
-            --wait-timeout 300 \
-            --env APP_VERSION=${{ env.APP_VERSION }}
+          for i in 1 2 3; do
+            flyctl deploy --config fly.prod.toml --remote-only \
+              --wait-timeout 300 \
+              --env APP_VERSION=${{ env.APP_VERSION }} && exit 0
+            echo "Deploy attempt $i failed. Retrying in 30s..."
+            sleep 30
+          done
+          exit 1
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_DEPLOY_TOKEN }}
 
@@ -187,12 +197,13 @@ jobs:
 
       - name: Install git-cliff
         run: |
-          curl -sLO https://github.com/orhun/git-cliff/releases/download/v2.6.0/git-cliff-2.6.0-x86_64-unknown-linux-gnu.tar.gz
-          curl -sLO https://github.com/orhun/git-cliff/releases/download/v2.6.0/git-cliff-2.6.0-x86_64-unknown-linux-gnu.tar.gz.sha512
-          echo "$(cat git-cliff-2.6.0-x86_64-unknown-linux-gnu.tar.gz.sha512 | cut -d' ' -f1)  git-cliff-2.6.0-x86_64-unknown-linux-gnu.tar.gz" | sha512sum -c -
-          sudo tar -xzf git-cliff-2.6.0-x86_64-unknown-linux-gnu.tar.gz --strip-components=1 -C /usr/local/bin
-          rm -f git-cliff-2.6.0-x86_64-unknown-linux-gnu.tar.gz git-cliff-2.6.0-x86_64-unknown-linux-gnu.tar.gz.sha512
-          || cargo install git-cliff@2.6.0
+          {
+            curl -sLO https://github.com/orhun/git-cliff/releases/download/v2.6.0/git-cliff-2.6.0-x86_64-unknown-linux-gnu.tar.gz
+            curl -sLO https://github.com/orhun/git-cliff/releases/download/v2.6.0/git-cliff-2.6.0-x86_64-unknown-linux-gnu.tar.gz.sha512
+            echo "$(cat git-cliff-2.6.0-x86_64-unknown-linux-gnu.tar.gz.sha512 | cut -d' ' -f1)  git-cliff-2.6.0-x86_64-unknown-linux-gnu.tar.gz" | sha512sum -c -
+            sudo tar -xzf git-cliff-2.6.0-x86_64-unknown-linux-gnu.tar.gz --strip-components=1 -C /usr/local/bin
+            rm -f git-cliff-2.6.0-x86_64-unknown-linux-gnu.tar.gz git-cliff-2.6.0-x86_64-unknown-linux-gnu.tar.gz.sha512
+          } || cargo install git-cliff@2.6.0
 
       - name: Generate changelog
         run: git-cliff --config .cligrc --output CHANGELOG.md

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -141,8 +141,10 @@ jobs:
               --env DEPLOYMENT_TIME=${{ env.DEPLOYMENT_TIME }} \
               --env COMMIT_SHA=${{ env.COMMIT_SHA }} \
               --env APP_VERSION=${{ env.APP_VERSION }} && exit 0
-            echo "Deploy attempt $i failed. Retrying in 30s..."
-            sleep 30
+            if [ "$i" -lt 3 ]; then
+              echo "Deploy attempt $i failed. Retrying in 30s..."
+              sleep 30
+            fi
           done
           exit 1
         env:
@@ -177,8 +179,10 @@ jobs:
             flyctl deploy --config fly.prod.toml --remote-only \
               --wait-timeout 300 \
               --env APP_VERSION=${{ env.APP_VERSION }} && exit 0
-            echo "Deploy attempt $i failed. Retrying in 30s..."
-            sleep 30
+            if [ "$i" -lt 3 ]; then
+              echo "Deploy attempt $i failed. Retrying in 30s..."
+              sleep 30
+            fi
           done
           exit 1
         env:


### PR DESCRIPTION
Fixes two CI/CD issues seen during the v1.3.1 release:\n\n1. Generate Changelog job failed with a shell syntax error because the fallback cargo install was on its own line. Grouped the install steps so the fallback runs correctly.\n2. Deploy to Production failed because a Fly.io machine lease was held by another process. Added a 3-attempt retry loop with a 30s backoff to both dev and prod deploy steps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced deployment reliability with improved retry mechanisms for production and development deployments.
  * Strengthened system dependency installation procedures with better fallback handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->