### PR TITLE
fix(entrypoint,scraper): scraper crashes with EACCES on heartbeat file

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -19,8 +19,8 @@ mkdir -p "$DATA_ROOT/csv" "$DATA_ROOT/html" "$DATA_ROOT/logs"
 # a recursive chown on every container start would slow startup and could exceed
 # Fly's health-check grace period.
 BUN_UID=$(id -u bun)
-CSV_OWNER=$(stat -c '%u' "$DATA_ROOT/csv" 2>/dev/null || echo 0)
-if [ "$CSV_OWNER" != "$BUN_UID" ]; then
+DATA_OWNER=$(stat -c '%u' "$DATA_ROOT" 2>/dev/null || echo 0)
+if [ "$DATA_OWNER" != "$BUN_UID" ]; then
     chown -R bun:bun "$DATA_ROOT"
 fi
 

--- a/src/scrappers/scrape_proCyclingStats.js
+++ b/src/scrappers/scrape_proCyclingStats.js
@@ -76,8 +76,9 @@ import path from "path";
  */
 function writeHeartbeat(label) {
   try {
-    const dataDir = process.env.DATA_DIR || "./data/csv";
-    const heartbeatPath = path.join(dataDir, "..", "last-scrape.txt");
+    const logDir = process.env.LOG_DIR || "/tourRanking/data/logs";
+    const heartbeatPath = path.join(logDir, "last-scrape.txt");
+    fs.mkdirSync(logDir, { recursive: true });
     fs.writeFileSync(heartbeatPath, `${new Date().toISOString()} ${label}\n`);
   } catch (error) {
     logError("Scraper", "Failed to write heartbeat", error);

--- a/src/scrappers/scrape_proCyclingStats.js
+++ b/src/scrappers/scrape_proCyclingStats.js
@@ -81,7 +81,6 @@ function writeHeartbeat(label) {
     fs.writeFileSync(heartbeatPath, `${new Date().toISOString()} ${label}\n`);
   } catch (error) {
     logError("Scraper", "Failed to write heartbeat", error);
-    throw error;
   }
 }
 // Scrape

--- a/src/server/controllers/health/last-scrape.js
+++ b/src/server/controllers/health/last-scrape.js
@@ -1,6 +1,5 @@
 import fs from "fs/promises";
 import path from "path";
-import config from "@server/config";
 import { logError } from "@utils/logging";
 
 /**
@@ -24,8 +23,8 @@ const DEFAULT_THRESHOLD_MS = 2 * 60 * 60 * 1000; // 2 hours
  *   - `"error"`     — heartbeat is missing or unreadable
  */
 export async function statusOfLastScrape() {
-  const dataDir = process.env.DATA_DIR || config.dataService.dataDir;
-  const heartbeatPath = path.join(dataDir, "..", "last-scrape.txt");
+  const logDir = process.env.LOG_DIR || "/tourRanking/data/logs";
+  const heartbeatPath = path.join(logDir, "last-scrape.txt");
 
   try {
     const content = await fs.readFile(heartbeatPath, "utf8");


### PR DESCRIPTION
## Problem

Fly.io dev scraper cron fails immediately with:

```
EACCES: permission denied, open '/tourRanking/data/last-scrape.txt'
error: script "scrape" exited with code 1
```

## Root cause

`writeHeartbeat()` was writing directly into `DATA_DIR` (`/tourRanking/data/last-scrape.txt`). Although `cooldown-3` already has the `DATA_ROOT` rename fix (#439), the entrypoint was still only verifying ownership of `$DATA_ROOT/csv`, so the parent directory could remain root-owned and break the write.

Additionally, `writeHeartbeat()` re-threw the error, turning a non-critical health heartbeat into a fatal scraper failure.

## Changes

- Move the heartbeat file into `LOG_DIR` (`/tourRanking/data/logs/last-scrape.txt`), which is created and chowned by the entrypoint alongside other operational logs.
- Check ownership of `$DATA_ROOT` itself rather than `$DATA_ROOT/csv` so any file written directly into the volume root is writable.
- Make `writeHeartbeat()` non-fatal: log the failure and continue scraping.
- Remove the now-unused `@server/config` import from `last-scrape.js`.

## GDPR / privacy

The heartbeat file contains only an ISO timestamp and a label (`started`/`completed`). No personal data is written or logged.

## Verification

- `bun run lint` ✅
- `bun test` ✅ (250 passing)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced permission initialisation logic to more efficiently and reliably verify persistent data directory ownership before applying necessary management changes
  * Refactored the scraper logging infrastructure to provide flexible, fully configurable log directory paths via environment variables
  * Updated system health monitoring checks to accurately read and report scraper status information from the newly configured logging location

<!-- end of auto-generated comment: release notes by coderabbit.ai -->