### PR TITLE
chore(release): v1.3.2

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -135,11 +135,18 @@ jobs:
 
       - name: Deploy to development
         run: |
-          flyctl deploy --config fly.dev.toml --remote-only \
-            --env BRANCH_NAME=${{ env.BRANCH_NAME }} \
-            --env DEPLOYMENT_TIME=${{ env.DEPLOYMENT_TIME }} \
-            --env COMMIT_SHA=${{ env.COMMIT_SHA }} \
-            --env APP_VERSION=${{ env.APP_VERSION }}
+          for i in 1 2 3; do
+            flyctl deploy --config fly.dev.toml --remote-only \
+              --env BRANCH_NAME=${{ env.BRANCH_NAME }} \
+              --env DEPLOYMENT_TIME=${{ env.DEPLOYMENT_TIME }} \
+              --env COMMIT_SHA=${{ env.COMMIT_SHA }} \
+              --env APP_VERSION=${{ env.APP_VERSION }} && exit 0
+            if [ "$i" -lt 3 ]; then
+              echo "Deploy attempt $i failed. Retrying in 30s..."
+              sleep 30
+            fi
+          done
+          exit 1
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_DEPLOY_TOKEN }}
 
@@ -168,9 +175,16 @@ jobs:
 
       - name: Deploy to production
         run: |
-          flyctl deploy --config fly.prod.toml --remote-only \
-            --wait-timeout 300 \
-            --env APP_VERSION=${{ env.APP_VERSION }}
+          for i in 1 2 3; do
+            flyctl deploy --config fly.prod.toml --remote-only \
+              --wait-timeout 300 \
+              --env APP_VERSION=${{ env.APP_VERSION }} && exit 0
+            if [ "$i" -lt 3 ]; then
+              echo "Deploy attempt $i failed. Retrying in 30s..."
+              sleep 30
+            fi
+          done
+          exit 1
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_DEPLOY_TOKEN }}
 
@@ -187,12 +201,13 @@ jobs:
 
       - name: Install git-cliff
         run: |
-          curl -sLO https://github.com/orhun/git-cliff/releases/download/v2.6.0/git-cliff-2.6.0-x86_64-unknown-linux-gnu.tar.gz
-          curl -sLO https://github.com/orhun/git-cliff/releases/download/v2.6.0/git-cliff-2.6.0-x86_64-unknown-linux-gnu.tar.gz.sha512
-          echo "$(cat git-cliff-2.6.0-x86_64-unknown-linux-gnu.tar.gz.sha512 | cut -d' ' -f1)  git-cliff-2.6.0-x86_64-unknown-linux-gnu.tar.gz" | sha512sum -c -
-          sudo tar -xzf git-cliff-2.6.0-x86_64-unknown-linux-gnu.tar.gz --strip-components=1 -C /usr/local/bin
-          rm -f git-cliff-2.6.0-x86_64-unknown-linux-gnu.tar.gz git-cliff-2.6.0-x86_64-unknown-linux-gnu.tar.gz.sha512
-          || cargo install git-cliff@2.6.0
+          {
+            curl -sLO https://github.com/orhun/git-cliff/releases/download/v2.6.0/git-cliff-2.6.0-x86_64-unknown-linux-gnu.tar.gz
+            curl -sLO https://github.com/orhun/git-cliff/releases/download/v2.6.0/git-cliff-2.6.0-x86_64-unknown-linux-gnu.tar.gz.sha512
+            echo "$(cat git-cliff-2.6.0-x86_64-unknown-linux-gnu.tar.gz.sha512 | cut -d' ' -f1)  git-cliff-2.6.0-x86_64-unknown-linux-gnu.tar.gz" | sha512sum -c -
+            sudo tar -xzf git-cliff-2.6.0-x86_64-unknown-linux-gnu.tar.gz --strip-components=1 -C /usr/local/bin
+            rm -f git-cliff-2.6.0-x86_64-unknown-linux-gnu.tar.gz git-cliff-2.6.0-x86_64-unknown-linux-gnu.tar.gz.sha512
+          } || cargo install git-cliff@2.6.0
 
       - name: Generate changelog
         run: git-cliff --config .cligrc --output CHANGELOG.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -612,3 +612,119 @@ When making any change, ask yourself:
 - **Default to not collecting.** If you can't justify why a data point is necessary for the feature, don't collect it.
 - **Default to not logging.** If you can't guarantee a log line contains zero PII, don't write it.
 - **Flag for review.** Add a comment or open a GitHub Discussion if you're unsure about a data handling decision. Privacy is better handled with a second pair of eyes.
+
+## Worktree and branch conventions
+
+This project uses a **bare clone** at `.bare` with `git worktree` to manage
+multiple branches side-by-side. Follow these rules when creating branches and
+worktrees.
+
+### Quick rules
+
+1. **Never guess the base branch.** The source branch is automatic.
+2. **Agents must not create `_`-prefixed worktrees.** Directories starting
+   with `_` are reserved for personal task management.
+3. **Worktree directory paths mirror branch names exactly.** Branch
+   `bet/rider-search` lives in directory `bet/rider-search`.
+4. **Always branch from the latest `cycle-*` or `cooldown-*` branch.** The
+   highest-numbered integration branch is the source. Cooldown follows cycle,
+   so `cooldown-3` is later than `cycle-3`, `cycle-4` is later than
+   `cooldown-3`, and so on.
+5. **Agents must never create new `cycle-*`, `cooldown-*`, or `main`
+   branches.** Those integration branches are created and advanced by the
+   project lead only.
+6. **The sequence is strict:** `cycle-N` → `cooldown-N` → `cycle-(N+1)` →
+   `cooldown-(N+1)` → ... A cooldown branch is only created after its cycle
+   is finished; the next cycle is only created after its cooldown is finished.
+7. **Integration branches are protected.** Never push directly to
+   `cycle-*`, `cooldown-*`, or `main`. Create a feature branch and open a PR.
+8. **Set the normal Git upstream to `origin/<branch>`** so `git push` and
+   `git pull` work automatically. Record the integration target separately
+   in `branch.<branch>.shapeup-target` for tooling.
+9. **Do not branch off another feature branch** unless explicitly asked.
+
+### Choosing the base branch
+
+The base branch is **automatic**: the latest `cycle-*` or `cooldown-*` branch
+by number. Agents do not choose.
+
+| Source branch | When it is latest |
+|---|---|
+| `cycle-N` | A new cycle has started and its cooldown has not yet been created. |
+| `cooldown-N` | The matching `cycle-N` has finished and cooldown work is ongoing. |
+
+All agent-created branches target this branch. Only the project lead handles
+`main` directly.
+
+If the issue does not make the source clear, look at the `_cycle` /
+`_cooldown` worktrees or ask before creating anything.
+
+### Branch naming
+
+Use the format `<category>/<short-kebab-description>`:
+
+- `bet/` — Shape Up bet / pitched work
+- `bugfix/` — bug fix
+- `feat/` — standalone feature
+- `docs/` — documentation
+- `deps/` — dependency updates
+- `ops/` — CI / infra / deployment
+- `test/` — exploratory or test branches
+- `spike/` — technical exploration and research
+- `circuit-breaker/` — abandoned bet (keep for learning)
+
+### Creating a worktree
+
+Use the helper script instead of running `git worktree` directly:
+
+```bash
+./scripts/new-worktree.sh <new-branch>
+
+# Examples
+./scripts/new-worktree.sh bet/rider-search
+./scripts/new-worktree.sh bugfix/prod-crash
+./scripts/new-worktree.sh ops/update-actions
+```
+
+This will:
+
+1. Create `<new-branch>` from the latest `cycle-*` / `cooldown-*` branch.
+2. Set the normal Git upstream to `origin/<new-branch>` so `git push` and
+   `git pull` work automatically.
+3. Record the integration branch as `branch.<branch>.shapeup-target` for
+   tooling.
+4. Create a worktree directory that matches the branch path exactly.
+
+### Rebasing and pull requests
+
+- Rebase onto the same source branch the worktree was created from (the
+  latest `cycle-*` or `cooldown-*`).
+- Open pull requests against that same branch.
+- Only deviate if a human explicitly says so.
+
+Because `new-worktree.sh` records the integration branch in
+`branch.<branch>.shapeup-target`, the helper scripts know the correct rebase/PR
+target, while the normal Git upstream stays pointed at `origin/<branch>` for
+standard push/pull.
+
+### Finishing a worktree
+
+1. Merge the branch into its recorded integration branch (e.g. `cycle-3`).
+2. Confirm it shows as merged:
+   ```bash
+   ./scripts/check-merged-worktrees.sh
+   ```
+3. Remove the worktree and delete the branch:
+   ```bash
+   cd .bare
+   git worktree remove ../<directory>
+   git branch -D <branch>
+   git push origin --delete <branch>
+   ```
+
+### Existing `_` directories
+
+Directories starting with `_` (e.g. `_client`, `_scrape`, `_main`, `_cycle`)
+are part of your personal task-management setup and are intentionally outside
+this convention. Agents should leave them alone unless explicitly asked to
+work with one.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,6 +153,51 @@ Branch from the current cycle or cooldown branch:
 2. Ensure all tests pass (`bun test`)
 3. Run lint (`bun run lint`)
 
+#### Determining the Correct Rebase Target
+
+The current integration branch is determined automatically by
+`scripts/new-worktree.sh`. It picks the latest `cycle-*` or `cooldown-*`
+branch, where `cooldown-N` is considered later than `cycle-N` for the same
+number. You can also resolve it manually:
+
+```bash
+git branch --list 'cycle*' 'cooldown*' --format='%(refname:short)' \
+  | grep -E '^(cycle|cooldown)(-[0-9]+)?$' \
+  | awk -F- '{
+      num = ($2 == "" ? 0 : $2)
+      phase = ($1 == "cooldown" ? 1 : 0)
+      print num " " phase " " $0
+    }' \
+  | sort -k1,1n -k2,2n \
+  | tail -1 \
+  | awk '{print $3}'
+```
+
+Always rebase onto this branch before creating a PR. If you used
+`scripts/new-worktree.sh`, the target is also stored in
+`branch.<name>.shapeup-target`:
+
+```bash
+git config --get branch.<your-branch>.shapeup-target
+```
+
+#### Working Directory
+
+Agents must do all work from inside the worktree directory for the branch
+they are currently working on. Do not switch branches or edit files from the
+repo root or from a different worktree. This keeps the active branch visible
+and prevents accidental changes leaking across branches.
+
+```bash
+# Good: work inside the branch's own directory
+cd docs/agent-rebase-conventions
+# edit, commit, push from here
+
+# Bad: editing from another worktree or the repo root
+cd ../_cooldown
+# changes here belong to cooldown-3, not your branch
+```
+
 ### Commit Format
 
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -665,6 +665,7 @@ Use the format `<category>/<short-kebab-description>`:
 
 - `bet/` — Shape Up bet / pitched work
 - `bugfix/` — bug fix
+- `hotfix/` — urgent production fix
 - `feat/` — standalone feature
 - `docs/` — documentation
 - `deps/` — dependency updates

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -181,6 +181,16 @@ fix(api): handle missing race data gracefully
 Returns empty array instead of 500 error when no data exists.
 ```
 
+### Branch Protection
+
+The following branches are protected on GitHub and **must be updated through pull requests** — direct pushes are rejected:
+
+- `main`
+- `cycle-*`
+- `cooldown-*`
+
+These branches also require status checks to pass before merging. For release work, open a PR from a release branch; do not attempt to push release commits or tags directly.
+
 ### Merge Strategy
 
 - **Bet → Cycle**: Merge commit with descriptive message

--- a/scripts/check-merged-worktrees.sh
+++ b/scripts/check-merged-worktrees.sh
@@ -1,17 +1,28 @@
 #!/usr/bin/env bash
+
+# Strict mode for safer scripts:
+#   -e  Exit immediately if any command fails.
+#   -u  Treat unset variables as an error.
+#   -o pipefail  If any command in a pipeline fails, the whole pipeline fails.
 set -euo pipefail
 
-# Check which non-prefixed worktrees have already been merged into their
-# recorded Shape Up integration branch (e.g. cycle-3, cooldown-3).
+# Print a list of non-prefixed worktrees whose remote upstream branch has
+# been deleted (i.e. squash-merged and cleaned up on origin).
 #
-# Usage: ./scripts/check-merged-worktrees.sh
-# Can be run from any worktree or the repository root.
+# Usage:
+#   ./scripts/check-merged-worktrees.sh
+#   ./scripts/check-merged-worktrees.sh | xargs -n1 git -C .bare worktree remove
 
+# SCRIPT_DIR = the directory this script lives in.
+# $(dirname "$0") gets the script's path, and `cd && pwd` converts it to an
+# absolute path (in case it was called as a relative path like ./scripts/...).
 SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd) || exit 1
 
-# Walk up to the repo root (the directory containing .bare)
+# Walk up the directory tree until we find a `.bare` directory.
+# This script lives inside the repo, so we need to find the repo root.
 ROOT="$SCRIPT_DIR"
 while [[ ! -d "$ROOT/.bare" && "$ROOT" != "/" ]]; do
+  # dirname removes the last path component, e.g. /a/b/c -> /a/b
   ROOT=$(dirname "$ROOT")
 done
 
@@ -20,36 +31,72 @@ if [[ ! -d "$ROOT/.bare" ]]; then
   exit 1
 fi
 
+# Move to the repo root so all relative paths line up with git's output.
 cd "$ROOT" || exit 1
+
+# BARE is the path to the bare Git repository inside the worktree layout.
 BARE=".bare"
 
-echo "Checking non-prefixed worktrees against their Shape Up target..."
-echo
+# Fetch from all remotes and prune deleted remote branches.
+# This makes sure Git knows which upstream branches are "[gone]".
+# Fail loudly if the fetch fails so we don't report stale information.
+git -C "$BARE" fetch --all -p
 
-git -C "$BARE" worktree list --porcelain | awk '
-  /^worktree / { path=substr($0,10); next }
-  /^branch /  {
-    branch=substr($0,8)
-    print path "\t" branch
-  }
-' | while IFS=$'\t' read -r path branch; do
+# Read the output of the command inside < <(...) line by line.
+# IFS=$'\t' splits each line on tabs into two variables: path and branch.
+# The `|| [[ -n "$path" ]]` part handles the last line if it doesn't end
+# with a newline (without it the loop might drop the final row).
+while IFS=$'\t' read -r path branch || [[ -n "$path" ]]; do
+
+  # Git gives absolute paths like /Users/.../tourrankings/ops/agent-workflow.
+  # Strip the repo root so we get the relative worktree directory name.
+  # `${path#"$ROOT"/}` removes "$ROOT/" from the start of $path.
   rel="${path#"$ROOT"/}"
+
+  # Git branches are reported as refs/heads/bugfix/foo.
+  # Strip refs/heads/ so we get just the branch name, e.g. bugfix/foo.
   b="${branch#refs/heads/}"
 
-  # Skip personal task-management worktrees (prefixed with _)
+  # Skip the bare repo entry (it has no branch).
+  [[ "$rel" == ".bare" ]] && continue
+
+  # Skip personal/task-management worktrees that start with "_".
+  # These are intentionally kept around even if their remote is gone.
   [[ "$rel" == _* ]] && continue
 
-  target=$(git -C "$BARE" config --get branch."$b".shapeup-target 2>/dev/null || true)
-
-  if [[ -z "$target" ]]; then
-    printf "%-45s -> %-45s | no Shape Up target configured | UNKNOWN\n" "$rel" "$b"
-  elif git -C "$BARE" show-ref --verify --quiet "refs/heads/$target"; then
-    if git -C "$BARE" branch --merged "$target" --format='%(refname:short)' | grep -qx "$b"; then
-      printf "%-45s -> %-45s | -> %-17s | MERGED\n" "$rel" "$b" "$target"
-    else
-      printf "%-45s -> %-45s | -> %-17s | NOT MERGED\n" "$rel" "$b" "$target"
-    fi
-  else
-    printf "%-45s -> %-45s | -> %-17s | target branch missing locally\n" "$rel" "$b" "$target"
+  # Ask Git for the upstream tracking status of this branch.
+  # %(upstream:short) would be something like origin/bugfix/foo.
+  # %(upstream:track) is either empty, [ahead N], [behind N], or [gone].
+  # We only care about "[gone]", which means the remote branch was deleted.
+  # A branch with no upstream returns empty output (exit 0); real errors
+  # should propagate so they don't silently skip worktrees.
+  if ! track=$(git -C "$BARE" for-each-ref --format='%(upstream:track)' "refs/heads/$b"); then
+    echo "Warning: failed to query upstream status for branch '$b'" >&2
+    continue
   fi
-done
+
+  # If the upstream is gone, the branch was likely merged on GitHub/GitLab
+  # and the remote branch was deleted. Print the worktree directory name.
+  [[ "$track" == *gone* ]] && printf '%s\n' "$rel"
+
+# < <(...) is process substitution: it feeds the output of the inner command
+# into the while loop as if it were a file. This avoids the subtle problems
+# that come from piping into a while loop (like variable scope issues).
+done < <(git -C "$BARE" worktree list --porcelain | awk '
+  # --porcelain gives machine-readable output with one fact per line.
+  # /^worktree / matches lines like:
+  #   worktree /Users/.../tourrankings/ops/agent-workflow
+  /^worktree / { path=substr($0,10); next }
+
+  # /^branch / matches lines like:
+  #   branch refs/heads/ops/agent-workflow
+  /^branch /  {
+    branch=substr($0,8)
+    # Print the path and branch separated by a tab.
+    print path "\t" branch
+  }
+')
+
+# Explicit success exit. The while loop can otherwise return a non-zero code
+# when read hits EOF, which would break piping into xargs.
+exit 0

--- a/scripts/check-merged-worktrees.sh
+++ b/scripts/check-merged-worktrees.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Check which non-prefixed worktrees have already been merged into their
+# recorded Shape Up integration branch (e.g. cycle-3, cooldown-3).
+#
+# Usage: ./scripts/check-merged-worktrees.sh
+# Can be run from any worktree or the repository root.
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd) || exit 1
+
+# Walk up to the repo root (the directory containing .bare)
+ROOT="$SCRIPT_DIR"
+while [[ ! -d "$ROOT/.bare" && "$ROOT" != "/" ]]; do
+  ROOT=$(dirname "$ROOT")
+done
+
+if [[ ! -d "$ROOT/.bare" ]]; then
+  echo "Error: bare repo '.bare' not found" >&2
+  exit 1
+fi
+
+cd "$ROOT" || exit 1
+BARE=".bare"
+
+echo "Checking non-prefixed worktrees against their Shape Up target..."
+echo
+
+git -C "$BARE" worktree list --porcelain | awk '
+  /^worktree / { path=substr($0,10); next }
+  /^branch /  {
+    branch=substr($0,8)
+    print path "\t" branch
+  }
+' | while IFS=$'\t' read -r path branch; do
+  rel="${path#"$ROOT"/}"
+  b="${branch#refs/heads/}"
+
+  # Skip personal task-management worktrees (prefixed with _)
+  [[ "$rel" == _* ]] && continue
+
+  target=$(git -C "$BARE" config --get branch."$b".shapeup-target 2>/dev/null || true)
+
+  if [[ -z "$target" ]]; then
+    printf "%-45s -> %-45s | no Shape Up target configured | UNKNOWN\n" "$rel" "$b"
+  elif git -C "$BARE" show-ref --verify --quiet "refs/heads/$target"; then
+    if git -C "$BARE" branch --merged "$target" --format='%(refname:short)' | grep -qx "$b"; then
+      printf "%-45s -> %-45s | -> %-17s | MERGED\n" "$rel" "$b" "$target"
+    else
+      printf "%-45s -> %-45s | -> %-17s | NOT MERGED\n" "$rel" "$b" "$target"
+    fi
+  else
+    printf "%-45s -> %-45s | -> %-17s | target branch missing locally\n" "$rel" "$b" "$target"
+  fi
+done

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -8,17 +8,20 @@ set -e
 # root briefly to ensure the required subdirectories exist and are writable by
 # the app user, then drops privileges and starts cron + the web server.
 
-DATA_DIR=/tourRanking/data
+# Persistent data mount point. This is intentionally NOT named DATA_DIR so it
+# does not shadow the DATA_DIR environment variable that the application reads
+# (e.g. /tourRanking/data/csv).
+DATA_ROOT=/tourRanking/data
 
-mkdir -p "$DATA_DIR/csv" "$DATA_DIR/html" "$DATA_DIR/logs"
+mkdir -p "$DATA_ROOT/csv" "$DATA_ROOT/html" "$DATA_ROOT/logs"
 
 # Only chown when the volume is not already owned by bun. As the data set grows,
 # a recursive chown on every container start would slow startup and could exceed
 # Fly's health-check grace period.
 BUN_UID=$(id -u bun)
-CSV_OWNER=$(stat -c '%u' "$DATA_DIR/csv" 2>/dev/null || echo 0)
+CSV_OWNER=$(stat -c '%u' "$DATA_ROOT/csv" 2>/dev/null || echo 0)
 if [ "$CSV_OWNER" != "$BUN_UID" ]; then
-    chown -R bun:bun "$DATA_DIR"
+    chown -R bun:bun "$DATA_ROOT"
 fi
 
 # Start supercronic and the webserver as the bun user.

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -19,8 +19,8 @@ mkdir -p "$DATA_ROOT/csv" "$DATA_ROOT/html" "$DATA_ROOT/logs"
 # a recursive chown on every container start would slow startup and could exceed
 # Fly's health-check grace period.
 BUN_UID=$(id -u bun)
-CSV_OWNER=$(stat -c '%u' "$DATA_ROOT/csv" 2>/dev/null || echo 0)
-if [ "$CSV_OWNER" != "$BUN_UID" ]; then
+DATA_OWNER=$(stat -c '%u' "$DATA_ROOT" 2>/dev/null || echo 0)
+if [ "$DATA_OWNER" != "$BUN_UID" ]; then
     chown -R bun:bun "$DATA_ROOT"
 fi
 

--- a/scripts/new-worktree.sh
+++ b/scripts/new-worktree.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Create a new feature worktree following the Shape Up branch convention.
+#
+# The source branch is always the latest cycle-* or cooldown-* branch.
+# Agents do not choose the base branch manually.
+#
+# The branch's upstream is set to origin/<branch> so push/pull work normally.
+# The Shape Up integration target is stored separately in
+# branch.<branch>.shapeup-target for tooling.
+#
+# Usage: ./scripts/new-worktree.sh <new-branch>
+#
+# Examples:
+#   ./scripts/new-worktree.sh bet/rider-search
+#   ./scripts/new-worktree.sh bugfix/prod-crash
+#   ./scripts/new-worktree.sh ops/update-actions
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd) || exit 1
+
+# Walk up to the repo root (the directory containing .bare)
+ROOT="$SCRIPT_DIR"
+while [[ ! -d "$ROOT/.bare" && "$ROOT" != "/" ]]; do
+  ROOT=$(dirname "$ROOT")
+done
+
+if [[ ! -d "$ROOT/.bare" ]]; then
+  echo "Error: bare repo '.bare' not found" >&2
+  exit 1
+fi
+
+cd "$ROOT" || exit 1
+BARE=".bare"
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 <new-branch>" >&2
+  exit 1
+fi
+
+branch="$1"
+
+# Enforce branch naming convention and prevent agents from creating integration branches
+if [[ "$branch" =~ ^(cycle|cooldown|main) ]]; then
+  echo "Error: agents must not create '$branch' integration branches" >&2
+  exit 1
+fi
+if [[ ! "$branch" =~ ^(bet|bugfix|feat|docs|deps|ops|test|hotfix|spike|circuit-breaker)/[a-z0-9_-]+$ ]]; then
+  echo "Error: branch name must match '<category>/<short-kebab-description>'" >&2
+  echo "Allowed categories: bet, bugfix, feat, docs, deps, ops, test, hotfix, spike, circuit-breaker" >&2
+  exit 1
+fi
+
+# Find the latest cycle-* or cooldown-* branch
+latest_integration() {
+  git -C "$BARE" branch --list 'cycle*' 'cooldown*' --format='%(refname:short)' \
+    | grep -E '^(cycle|cooldown)(-[0-9]+)?$' \
+    | awk -F- '{
+        num = ($2 == "" ? 0 : $2)
+        phase = ($1 == "cooldown" ? 1 : 0)
+        print num " " phase " " $0
+      }' \
+    | sort -k1,1n -k2,2n \
+    | tail -1 \
+    | awk '{print $3}'
+}
+
+base=$(latest_integration)
+
+if [[ -z "$base" ]]; then
+  echo "Error: no cycle-* or cooldown-* branch exists yet" >&2
+  echo "The project lead creates these branches; agents cannot." >&2
+  exit 1
+fi
+
+if ! git -C "$BARE" show-ref --verify --quiet "refs/heads/$base"; then
+  echo "Error: base branch '$base' not found locally" >&2
+  exit 1
+fi
+
+if [[ "$base" == "$branch" ]]; then
+  echo "Error: new branch cannot be the same as the base branch" >&2
+  exit 1
+fi
+
+# Worktree directory path mirrors the branch name exactly
+dir="$branch"
+
+if [[ -e "$dir" ]]; then
+  echo "Error: directory '$dir' already exists" >&2
+  exit 1
+fi
+
+if git -C "$BARE" show-ref --verify --quiet "refs/heads/$branch"; then
+  echo "Error: branch '$branch' already exists" >&2
+  exit 1
+fi
+
+# Create the branch from the integration branch
+git -C "$BARE" branch "$branch" "$base"
+
+# Set normal upstream to the branch itself (origin/<branch>) for push/pull
+git -C "$BARE" config "branch.$branch.remote" origin
+git -C "$BARE" config "branch.$branch.merge" "refs/heads/$branch"
+
+# Remember the Shape Up integration target separately
+git -C "$BARE" config "branch.$branch.shapeup-target" "$base"
+
+# Create the remote branch and confirm upstream
+git -C "$BARE" push -u origin "$branch"
+
+# Add the worktree at the repo root, creating parent directories if needed
+mkdir -p "$(dirname "$dir")"
+git -C "$BARE" worktree add "../$dir" "$branch"
+
+echo "Created worktree '$dir' on branch '$branch' from '$base'."

--- a/scripts/new-worktree.sh
+++ b/scripts/new-worktree.sh
@@ -51,6 +51,9 @@ if [[ ! "$branch" =~ ^(bet|bugfix|feat|docs|deps|ops|test|hotfix|spike|circuit-b
   exit 1
 fi
 
+# Make sure local cycle/cooldown refs are current before choosing a base.
+git -C "$BARE" fetch origin
+
 # Find the latest cycle-* or cooldown-* branch
 latest_integration() {
   git -C "$BARE" branch --list 'cycle*' 'cooldown*' --format='%(refname:short)' \

--- a/src/scrappers/scrape_proCyclingStats.js
+++ b/src/scrappers/scrape_proCyclingStats.js
@@ -76,12 +76,12 @@ import path from "path";
  */
 function writeHeartbeat(label) {
   try {
-    const dataDir = process.env.DATA_DIR || "./data/csv";
-    const heartbeatPath = path.join(dataDir, "..", "last-scrape.txt");
+    const logDir = process.env.LOG_DIR || "/tourRanking/data/logs";
+    const heartbeatPath = path.join(logDir, "last-scrape.txt");
+    fs.mkdirSync(logDir, { recursive: true });
     fs.writeFileSync(heartbeatPath, `${new Date().toISOString()} ${label}\n`);
   } catch (error) {
     logError("Scraper", "Failed to write heartbeat", error);
-    throw error;
   }
 }
 // Scrape

--- a/src/server/controllers/health/last-scrape.js
+++ b/src/server/controllers/health/last-scrape.js
@@ -1,6 +1,5 @@
 import fs from "fs/promises";
 import path from "path";
-import config from "@server/config";
 import { logError } from "@utils/logging";
 
 /**
@@ -24,8 +23,8 @@ const DEFAULT_THRESHOLD_MS = 2 * 60 * 60 * 1000; // 2 hours
  *   - `"error"`     — heartbeat is missing or unreadable
  */
 export async function statusOfLastScrape() {
-  const dataDir = process.env.DATA_DIR || config.dataService.dataDir;
-  const heartbeatPath = path.join(dataDir, "..", "last-scrape.txt");
+  const logDir = process.env.LOG_DIR || "/tourRanking/data/logs";
+  const heartbeatPath = path.join(logDir, "last-scrape.txt");
 
   try {
     const content = await fs.readFile(heartbeatPath, "utf8");


### PR DESCRIPTION
Patch release from cooldown-3 to main.

Includes the following changes since v1.3.1:

- docs(agents): document branch protection rules (#437)
- fix(ci): correct changelog install syntax and add deploy retries (#438)
- fix(entrypoint): stop shadowing DATA_DIR env var (#439)
- fix(entrypoint,scraper): scraper crashes with EACCES on heartbeat file (#440)
- docs: add agent worktree/branch conventions and helper scripts (#441)
- Ops/worktree cleanup script (#442)
- docs(agents): clarify rebase target and working directory (#443)

After merging, tag main with `v1.3.2`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved deployment reliability with automatic retry logic; deployments now retry up to three times on failure.
  * Updated logging and data storage configuration for better container management.
  * Enhanced developer workflow documentation and tooling for internal team processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->