### PR TITLE
fix(scripts): use remote refs and enforce kebab-case in new-worktree

### DIFF
--- a/scripts/new-worktree.sh
+++ b/scripts/new-worktree.sh
@@ -45,7 +45,7 @@ if [[ "$branch" =~ ^(cycle|cooldown|main) ]]; then
   echo "Error: agents must not create '$branch' integration branches" >&2
   exit 1
 fi
-if [[ ! "$branch" =~ ^(bet|bugfix|feat|docs|deps|ops|test|hotfix|spike|circuit-breaker)/[a-z0-9_-]+$ ]]; then
+if [[ ! "$branch" =~ ^(bet|bugfix|feat|docs|deps|ops|test|hotfix|spike|circuit-breaker)/[a-z0-9-]+$ ]]; then
   echo "Error: branch name must match '<category>/<short-kebab-description>'" >&2
   echo "Allowed categories: bet, bugfix, feat, docs, deps, ops, test, hotfix, spike, circuit-breaker" >&2
   exit 1
@@ -54,9 +54,10 @@ fi
 # Make sure local cycle/cooldown refs are current before choosing a base.
 git -C "$BARE" fetch origin
 
-# Find the latest cycle-* or cooldown-* branch
+# Find the latest cycle-* or cooldown-* branch from remote-tracking refs
 latest_integration() {
-  git -C "$BARE" branch --list 'cycle*' 'cooldown*' --format='%(refname:short)' \
+  git -C "$BARE" branch -r --list 'origin/cycle*' 'origin/cooldown*' --format='%(refname:short)' \
+    | sed 's|^origin/||' \
     | grep -E '^(cycle|cooldown)(-[0-9]+)?$' \
     | awk -F- '{
         num = ($2 == "" ? 0 : $2)
@@ -76,8 +77,8 @@ if [[ -z "$base" ]]; then
   exit 1
 fi
 
-if ! git -C "$BARE" show-ref --verify --quiet "refs/heads/$base"; then
-  echo "Error: base branch '$base' not found locally" >&2
+if ! git -C "$BARE" show-ref --verify --quiet "refs/remotes/origin/$base"; then
+  echo "Error: base branch '$base' not found on origin" >&2
   exit 1
 fi
 
@@ -99,8 +100,8 @@ if git -C "$BARE" show-ref --verify --quiet "refs/heads/$branch"; then
   exit 1
 fi
 
-# Create the branch from the integration branch
-git -C "$BARE" branch "$branch" "$base"
+# Create the branch from the latest remote integration branch
+git -C "$BARE" branch "$branch" "origin/$base"
 
 # Set normal upstream to the branch itself (origin/<branch>) for push/pull
 git -C "$BARE" config "branch.$branch.remote" origin


### PR DESCRIPTION
Addresses CodeRabbit review comments on #445.

- Select the latest integration branch from `origin/*` remote-tracking refs after fetching, ensuring the base is current.
- Create the new branch from `origin/$base` instead of a possibly stale local tracking branch.
- Remove underscore from the description regex so branch names are true kebab-case.