### PR TITLE
docs(workflow): add human branching workflow guide and git alias

### DIFF
--- a/development-guidlines.md
+++ b/development-guidlines.md
@@ -2,6 +2,8 @@
 
 This document outlines the development workflow for this project, based on Shape Up methodology combined with git best practices.
 
+> **Human quick reference:** For the concise branching and phase-branch creation guide, see [`docs/branching-workflow.md`](docs/branching-workflow.md). This file covers the full conventions in more detail.
+
 ## Branch Naming Conventions
 
 ### Production & Integration Branches

--- a/docs/branching-workflow.md
+++ b/docs/branching-workflow.md
@@ -1,0 +1,83 @@
+# Branching Workflow for Humans
+
+This is the quick-reference guide for creating and managing Shape Up phase branches (`cycle-*` and `cooldown-*`).
+
+For the full agent conventions, see [`AGENTS.md`](../AGENTS.md).
+
+## TL;DR
+
+```bash
+# Create the next cycle or cooldown branch
+./scripts/setup-git-aliases.sh        # one-time setup
+git next-phase cycle-4 cooldown-3     # create and push cycle-4 from cooldown-3
+```
+
+## Shape Up branches
+
+| Branch | Purpose | Created by |
+|---|---|---|
+| `main` | Production code | Project lead only |
+| `cycle-{n}` | 6-week build phase | Project lead only |
+| `cooldown-{n}` | 2-week cooldown/maintenance | Project lead only |
+| `bet/{name}` | Shaped work | Anyone |
+| `bugfix/{name}` | Bug fixes | Anyone |
+
+## Creating a new phase branch
+
+### 1. Install the alias (one-time)
+
+```bash
+./scripts/setup-git-aliases.sh
+```
+
+This adds a `next-phase` alias to the local repository’s Git config.
+
+### 2. Create and push the branch
+
+```bash
+# explicit source
+git next-phase cycle-4 cooldown-3
+
+# or use the default origin/HEAD
+git next-phase cycle-4
+```
+
+This is equivalent to:
+
+```bash
+git fetch origin
+git switch -c cycle-4 origin/cooldown-3
+git push -u origin cycle-4
+```
+
+## Important: repository rules
+
+The GitHub branch protection rules for `cycle-*` / `cooldown-*` must **allow merge commits**. These branches are created from previous phase branches that already contain merge commits, and `cycle-{n} → main` releases are intentionally done as merge commits.
+
+If you see:
+
+```text
+remote: error: GH013: Repository rule violations found for refs/heads/cycle-4.
+remote: - This branch must not contain merge commits.
+```
+
+The fix is in GitHub Settings → Branches → Branch protection rules:
+
+- Uncheck **"Require linear history"** for `cycle-*`, `cooldown-*`, and `main`.
+- Keep **"Require a pull request before merging"** and status checks enabled.
+
+## Worktrees
+
+This project uses bare clone + worktrees. To start work on a new bet or bugfix, use the helper:
+
+```bash
+./scripts/new-worktree.sh bet/my-feature
+```
+
+This creates a matching worktree directory and branch from the current `cycle-*` or `cooldown-*` branch.
+
+## See also
+
+- [`AGENTS.md`](../AGENTS.md) — full agent/worktree/branch conventions
+- [`scripts/new-worktree.sh`](../scripts/new-worktree.sh) — create a bet/bugfix worktree
+- [`scripts/check-merged-worktrees.sh`](../scripts/check-merged-worktrees.sh) — clean up finished worktrees

--- a/scripts/setup-git-aliases.sh
+++ b/scripts/setup-git-aliases.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+#
+# Set up local git aliases for the Shape Up branching workflow.
+# Run once per repository (aliases are shared across all worktrees).
+#
+
+set -euo pipefail
+
+if ! git rev-parse --git-dir > /dev/null 2>&1; then
+    echo "Error: not inside a git repository" >&2
+    exit 1
+fi
+
+ALIAS_NAME="next-phase"
+ALIAS_VALUE='!f() { \
+    name=$1; \
+    source=${2:-$(git rev-parse --abbrev-ref origin/HEAD | sed "s/^origin\///")}; \
+    git fetch origin && \
+    git switch -c "$name" "origin/$source" && \
+    git push -u origin "$name"; \
+}; f'
+
+if git config --local "alias.$ALIAS_NAME" > /dev/null 2>&1; then
+    echo "Git alias '$ALIAS_NAME' already exists in this repository."
+    echo "Current value: $(git config --local "alias.$ALIAS_NAME")"
+    exit 0
+fi
+
+git config --local "alias.$ALIAS_NAME" "$ALIAS_VALUE"
+
+echo "Installed git alias '$ALIAS_NAME' in $(git config --local core.repositoryformatversion >/dev/null 2>&1 && git rev-parse --show-toplevel || git rev-parse --git-dir)."
+echo ""
+echo "Usage:"
+echo "  git next-phase cycle-4 cooldown-3"
+echo "  git next-phase cycle-4            # uses origin/HEAD"


### PR DESCRIPTION
- Add docs/branching-workflow.md quick-reference for Shape Up phase branches
- Add scripts/setup-git-aliases.sh to install the git next-phase alias
- Link to the new doc from development-guidlines.md